### PR TITLE
Galaxy tool automation PR

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+STAGING_URL=https://galaxy-cat.genome.edu.au
+PRODUCTION_URL=https://cat-dev.genome.edu.au
+STAGING_TOOL_DIR=galaxy-cat
+PRODUCTION_TOOL_DIR=cat-dev
+
+# STAGING_DIR='galaxy-aust-staging'
+# PRODUCTION_DIR='usegalaxy.org.au'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+.env
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .venv
-.env
+.secret.env
 tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 install:
 - pip install -r .travis/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install:
+  - pip install -r requirements.txt
+script: .travis/travis.sh
+build_pushes: false
+notifications:
+  email: false
+# before_install:
+#   - echo 'first travis script'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
 python:
-  - "2.7"
-  - "3.5"
+- '2.7'
+- '3.5'
 install:
-  - pip install -r requirements.txt
-script: .travis/travis.sh
+- pip install -r .travis/requirements.txt
+script: ".travis/travis.sh"
 build_pushes: false
 notifications:
   email: false
-# before_install:
-#   - echo 'first travis script'
+env:
+  global:
+  - secure: KwpJpZHotNZAlM9eJTyBn9VVClY3QUQ447Nhjrb0R/8xxmyNYvq3n+jct7r+eRV6oJUvpsJ8yq5PWka1eB290UEsj2dE4UhQMs9zBASYTkduiJL8EBAoMnLS/mJdCrCa35DecKwj9kFoJRhZp6j1t41n0JUFO10XhWD7wb1hq4MwJaDf6MmaLmqe9kNgjSqYiA5CWesFqnhbIpmaMyg20+HdUoacr8kTqlHMaiAONmsuBLSxyngMsrXTF6+SgGCwvGVVcACEqs+sx69Sr/+dazicx9s+8ZxrVa+N09x1mpBM0Os1yMHuZUKN7B6BuuJyGKJNwPz//ypaOi85Ec5EqmTsKGJALTKXIeyWEWRdc0o9Q/ePeRlggdruqhSZF2WD8MN8tYex1O0KAOG96yEdzjqgSimnjgtBRyrhKM6uF5l2joLKPbJZyQEbukpuYIKklF58GxEk6pojoOPGxeL1FVyhuLm/Huka4L/f5pz1b+Koxci3BY0BD2feda57AqhO4SjtAzx0J1kFjpMkXiHvCR1xaNt8iHD4VVJLSocTQ+mHy8b/qB+PDC9ZUZaISRwfuoSNKQj278F1pD/1IgJy8HVujG8ZjAEljbRFu88aBTTCnAGkASK+TcX90/lWm4XOSoGn6RAj9DyejH+abLUVMuixh4BUZxwdjxjhjmkRpmk=
+  - secure: jCCncxNjLKuRTekKKd6xaTNPyqoNt/vMZd+ZbZbGMUStFsmPRX9JKDDa316L+4bL/NiJ2enQQ1n4mpWFsWLIr/ir0WMYb34mq7EtuAYtFuIpRevde7AtCtWRJNfE9/4cgW1gQWW2donIaBFpIKpAZWPVTFkUB35/0CqeLeSnoHfE7LzgYcDMho3tAAu95Pkodm6ZG7b7Jgg86ezSWuJNWLaWTjqmLXjvPPsc/Uh7jlfiRr7AfXf0IUcNImhl5gkEFWJTUZIVQTBPwfmRP9JZoY6jPuoAY2o1E/o6acfkEfj/1IWKgFBrV+9mwD6N94d5Ld1PJIAl+Es0qK8X7dBpEGeJYng5Hj1WOgrRawf9vrhEzWVVkjTadwAwxU1dUk2AHfY/Vk4VXo6L07eho69v5TSec6DqKCKnPJnAa4Qb+NMuxBwHbZRsoYEPo3Mj3+UTM41h423upGOi/FAnK4AdeLCKayLibtJRopzAXOmFoOR/jkXMXFttPetOIxviXn1nMrK73ZmYetcrW3wpeHR1XYteFsTHKIuDzDcQDk+VxhwHlxphDsZOq4yuFuXbjPCR3otoy8Ep46UzZL5p+6r72Tr20phCc/Cf2ydTQAPBSB4EIkvoQq4zC9RvzzI0SNT8SOL/O4qYRbqWdzeurCzmNZXoSXFhgjAgYBLd1rltb70=

--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -11,8 +11,6 @@ from bioblend.toolshed.repositories import ToolShedRepositoryClient
 default_tool_shed = 'toolshed.g2.bx.psu.edu'
 
 mandatory_keys = ['name', 'tool_panel_section_label', 'owner']
-allowed_keys = ['tool_shed_url', 'revisions', 'ignore_test_errors']
-forbidden_keys = ['tool_panel_section_id']
 
 
 def main():
@@ -141,7 +139,8 @@ def check_installable(tools):
                 for revision in tool['revisions']:
                     if shed_status == 'online':
                         if revision not in installable_revisions:
-                            errors.append('% revision %s is not installable' % (tool['name'], revision))
+                            print(revision, installable_revisions)
+                            errors.append('%s revision %s is not installable' % (tool['name'], revision))
                     tool.update({'revision_request_type': 'specific', 'shed_status': shed_status})
             else:
                 if shed_status == 'online':

--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -139,7 +139,6 @@ def check_installable(tools):
                 for revision in tool['revisions']:
                     if shed_status == 'online':
                         if revision not in installable_revisions:
-                            print(revision, installable_revisions)
                             errors.append('%s revision %s is not installable' % (tool['name'], revision))
                     tool.update({'revision_request_type': 'specific', 'shed_status': shed_status})
             else:

--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -1,0 +1,58 @@
+import argparse
+import yaml
+import sys
+
+from bioblend.galaxy import GalaxyInstance
+from bioblend.galaxy.tools import ToolClient
+
+
+parser = argparse.ArgumentParser(description="Lint tool input files for installation on Galaxy")
+parser.add_argument('-f', '--files', help='Tool input files', nargs='+')
+
+args = parser.parse_args()
+files = args.files
+
+mandatory_keys = [
+    'name', 'tool_panel_section_label', 'tool_shed_url', 'owner'
+]
+
+allowed_keys = ['revisions', 'ignore_test_errors']
+
+forbidden_keys = ['tool_panel_section_id']  # this is unnecessary if we have allowed_keys check
+
+
+loaded_files = []
+for file in files:
+    with open(file) as file_in:
+        # As a first pass, check that yaml loads
+        loaded_yml = yaml.safe_load(file_in.read()) # might throw exception here
+        loaded_files.append({
+            'yaml': loaded_yml,
+            'filename': file,
+        })
+
+for loaded_file in loaded_files:
+    sys.stderr.write('Checking %s ... ' % loaded_file['filename'])
+    if not 'tools' in loaded_file['yaml'].keys():
+        system.out.write('ERROR\n')
+        raise Exception('Expecting .yml file with \'tools\'. Check requests/template/template.yml for an example.')
+    tools = loaded_file['yaml']['tools']
+    if not isinstance(tools, list):
+        tools = [tools]
+    for key in mandatory_keys:
+        for tool in tools:
+            if not key in tool.keys():
+                system.out.write('ERROR\n')
+                raise Exception('All tool list entries must have \'%s\' specified. Check requests/template/template.yml for an example.' % key)
+        if key == 'tool_panel_section_label':
+            pass # TODO: Check that section header is valid
+            #
+
+    sys.stderr.write('OK\n')
+
+# Use bioblend to check whether the package is already installed.  Need to do this without
+# making the API keys public
+
+# galaxy_instance = GalaxyInstance(url=galaxy_url, key=galaxy_api_key)
+# tool_client = ToolClient(galaxy_instance)
+# panel = tool_client.get_tool_panel()

--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -2,57 +2,179 @@ import argparse
 import yaml
 import sys
 
+from bioblend import ConnectionError
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.tools import ToolClient
+from bioblend.galaxy.toolshed import ToolShedClient
+from bioblend.toolshed import ToolShedInstance
+from bioblend.toolshed.repositories import ToolShedRepositoryClient
+
+default_tool_shed = 'toolshed.g2.bx.psu.edu'
+
+mandatory_keys = ['name', 'tool_panel_section_label', 'owner']
+allowed_keys = ['tool_shed_url', 'revisions', 'ignore_test_errors']
+forbidden_keys = ['tool_panel_section_id']
+
+def main():
+    parser = argparse.ArgumentParser(description="Lint tool input files for installation on Galaxy")
+    parser.add_argument('-f', '--files', help='Tool input files', nargs='+')
+    parser.add_argument('-u', '--staging_url', help='Galaxy staging server URL')
+    parser.add_argument('-k', '--staging_api_key', help='API key for galaxy staging server')
+    parser.add_argument('-g', '--production_url', help='Galaxy production server URL')
+    parser.add_argument('-a', '--production_api_key', help='API key for galaxy production server')
+
+    args = parser.parse_args()
+    files = args.files
+    staging_url = args.staging_url
+    staging_api_key = args.staging_api_key
+    production_url = args.production_url
+    production_api_key = args.production_api_key
+
+    loaded_files = yaml_check(args.files) # load yaml and raise ParserError if yaml is incorrect
+    key_check(loaded_files)
+    tool_list = join_lists([x['yaml']['tools'] for x in loaded_files])
+    installable_errors = check_installable(tool_list)
+    installed_errors_staging = check_tools_against_panel(staging_url, staging_api_key, tool_list)
+    installed_errors_production = check_tools_against_panel(production_url, production_api_key, tool_list)
+
+    all_warnings = installed_errors_staging  # If a tool is installed on staging but not production, do not raise an exception
+    all_errors = installable_errors + installed_errors_production
+    if all_errors:
+        sys.stderr.write('\n')
+        for error in all_errors:
+            sys.stderr.write('Error %s\n' % error)
+        raise Exception('Errors found')
+    else:
+        sys.stderr.write('All tools are installable and not already installed on %s\n' % production_url)
 
 
-parser = argparse.ArgumentParser(description="Lint tool input files for installation on Galaxy")
-parser.add_argument('-f', '--files', help='Tool input files', nargs='+')
-
-args = parser.parse_args()
-files = args.files
-
-mandatory_keys = [
-    'name', 'tool_panel_section_label', 'tool_shed_url', 'owner'
-]
-
-allowed_keys = ['revisions', 'ignore_test_errors']
-
-forbidden_keys = ['tool_panel_section_id']  # this is unnecessary if we have allowed_keys check
+def join_lists(list_of_lists):
+    return [entry for list in list_of_lists for entry in list]
 
 
-loaded_files = []
-for file in files:
-    with open(file) as file_in:
-        # As a first pass, check that yaml loads
-        loaded_yml = yaml.safe_load(file_in.read()) # might throw exception here
-        loaded_files.append({
-            'yaml': loaded_yml,
-            'filename': file,
-        })
+def flatten_tool_list(tool_list):
+    flattened_tool_list = []
+    for tool in tool_list:
+        if 'revisions' in  tool.keys():
+            for revision in tool['revisions']:
+                copy_of_tool = tool.copy()
+                copy_of_tool['revisions'] = [revision]
+                flattened_tool_list.append(copy_of_tool)
+        else:
+            copy_of_tool = tool.copy()
+            flattened_tool_list.append(copy_of_tool)
+    return flattened_tool_list
 
-for loaded_file in loaded_files:
-    sys.stderr.write('Checking %s ... ' % loaded_file['filename'])
-    if not 'tools' in loaded_file['yaml'].keys():
-        system.out.write('ERROR\n')
-        raise Exception('Expecting .yml file with \'tools\'. Check requests/template/template.yml for an example.')
-    tools = loaded_file['yaml']['tools']
-    if not isinstance(tools, list):
-        tools = [tools]
-    for key in mandatory_keys:
-        for tool in tools:
-            if not key in tool.keys():
-                system.out.write('ERROR\n')
-                raise Exception('All tool list entries must have \'%s\' specified. Check requests/template/template.yml for an example.' % key)
-        if key == 'tool_panel_section_label':
-            pass # TODO: Check that section header is valid
-            #
 
-    sys.stderr.write('OK\n')
+def yaml_check(files):
+    loaded_files = []
+    for file in files:
+        with open(file) as file_in:
+            # As a first pass, check that yaml loads
+            try:
+                loaded_yml = yaml.safe_load(file_in.read()) # might throw exception here
+            except yaml.parser.ParserError as e:
+                raise e
+            loaded_files.append({
+                'yaml': loaded_yml,
+                'filename': file,
+            })
+    return loaded_files
 
-# Use bioblend to check whether the package is already installed.  Need to do this without
-# making the API keys public
+def key_check(loaded_files):  # TODO label check in this method
+    flattened_tools = []
+    for loaded_file in loaded_files:
+        sys.stderr.write('Checking %s \t ' % loaded_file['filename'])
+        if not 'tools' in loaded_file['yaml'].keys():
+            sys.stderr.write('ERROR\n')
+            raise Exception('Expecting .yml file with \'tools\'. Check requests/template/template.yml for an example.')
+        tools = loaded_file['yaml']['tools']
+        if not isinstance(tools, list):
+            tools = [tools]
+        for key in mandatory_keys:
+            for tool in tools:
+                if not key in tool.keys():
+                    sys.stderr.write('ERROR\n')
+                    raise Exception('All tool list entries must have \'%s\' specified. Check requests/template/template.yml for an example.' % key)
+            if key == 'tool_panel_section_label':
+                pass # TODO: Check that section label is valid
+                #
+        sys.stderr.write('OK\n')
 
-# galaxy_instance = GalaxyInstance(url=galaxy_url, key=galaxy_api_key)
-# tool_client = ToolClient(galaxy_instance)
-# panel = tool_client.get_tool_panel()
+
+def check_installable(tools):
+    # Go through all tool_shed_url values in request files and run get_ordered_installable_revisions
+    # to ascertain whether the specified revision is installable
+    errors = []
+    tools_by_shed = {}
+    for tool in tools:
+        if not 'tool_shed_url' in tool.keys():
+            tool.update({'tool_shed_url': default_tool_shed_url})
+        if tool['tool_shed_url'] in tools_by_shed.keys():
+            tools_by_shed[tool['tool_shed_url']].append(tool)
+        else:
+            tools_by_shed[tool['tool_shed_url']] = [tool]
+
+    for shed in tools_by_shed.keys():
+        url = 'https://%s' % shed
+        toolshed = ToolShedInstance(url=url)
+        repo_client = ToolShedRepositoryClient(toolshed)
+
+        for counter, tool in enumerate(tools_by_shed[shed]):
+            try:
+                installable_revisions = repo_client.get_ordered_installable_revisions(tool['name'], tool['owner'])
+                if counter == 0:
+                    sys.stderr.write('Connected to toolshed %s\n' % url)
+                installable_revisions = [str(r) for r in installable_revisions][::-1]  # un-unicode and list most recent first
+                # TODO make absolutely sure that the ordering is now correct
+                if not installable_revisions:
+                    errors.append('Tool with name: %s, owner: %s and tool_shed_url: %s has no installable revisions' % (tool['name'], tool['owner'], shed))
+                    continue
+                shed_status = 'online'
+            except ConnectionError:
+                if counter == 0:
+                    print('Could not connect to toolshed %s\n' % url)
+                shed_status = 'offline'
+                # Raise an exception?  Ask Simon.
+
+            if 'revisions' in tool.keys():  # Check that requested revisions are installable
+                for revision in revisions:
+                    if shed_status == 'online':
+                        if not revision in installable_revisions:
+                            errors.append('% revision %s is not installable' % (tool['name'], revision))
+                    tool.update({'revision_request_type': 'specific', 'shed_status': shed_status})
+            else:
+                if shed_status == 'online':
+                    tool.update({'revisions': [installable_revisions[0]]})
+                tool.update({'revision_request_type': 'latest', 'shed_status': shed_status})
+    return errors
+
+
+def check_tools_against_panel(galaxy_url, galaxy_api_key, tools):
+    galaxy_instance = GalaxyInstance(url=galaxy_url, key=galaxy_api_key)
+    tool_client = ToolClient(galaxy_instance)
+    panel = tool_client.get_tool_panel()
+    requested_tools = flatten_tool_list(tools)
+
+    errors = []
+    # the tool panel returned is a list of sections.
+    # each section is a dict, dict['elems'] is a list of installed tools
+    for section in [p for p in panel if 'elems' in p.keys()]:
+        for elem in section['elems']:
+            if 'tool_shed_repository' in elem.keys():
+                repo = elem['tool_shed_repository']
+                # tool is installed if 'name', 'owner' and 'revision' all match
+                matching_tools = [tool for tool in requested_tools if tool['shed_status'] == 'online' and
+                    (tool['name'], tool['owner'], tool['revisions'][0], tool['tool_shed_url']) ==
+                    (repo['name'], repo['owner'], str(repo['changeset_revision']), repo['tool_shed'])
+                ]
+                if matching_tools:
+                    tool = matching_tools[0]
+                    errors.append(
+                        'Tool with name: %s, owner: %s, revision: %s, tool_shed_url: %s is already installed on %s' %
+                        (tool['name'], tool['owner'], tool['revisions'][0], tool['tool_shed_url'], galaxy_url)
+                    )
+    return errors
+
+
+if __name__ == "__main__": main()

--- a/.travis/requirements.txt
+++ b/.travis/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+bioblend

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -1,18 +1,16 @@
-STAGING_URL='https://galaxy-cat.genome.edu.au'  # TODO: when using this in production swap this to 'galaxy-aust-staging' (commented out below)
-PRODUCTION_URL='https://cat-dev.genome.edu.au'  # TODO: when using this in production swap this to 'usegalaxy.org.au' (commented out below)
-STAGING_DIR='galaxy-cat'  # TODO: when using this in production swap this to 'galaxy-aust-staging' (commented out below)
-PRODUCTION_DIR='cat-dev'  # TODO: when using this in production swap this to 'usegalaxy.org.au' (commented out below)
+#! /bin/bash
 
-# STAGING_DIR='galaxy-aust-staging'
-# PRODUCTION_DIR='usegalaxy.org.au'
-
+# This script will run for a pull request or will run locally if the argument
+# 'local' is provided
 if [ ! $TRAVIS_PULL_REQUEST ] && [ ! "$@" = "local" ]; then
   exit 0;
 fi
 
+export $(cat .env)  # Load non-secret enviroment variables e.g. $STAGING_URL
+
 if [[ "$@" = "local" ]]; then
   TRAVIS_BRANCH=master
-  export $(cat .env)
+  export $(cat .secret.env)  # secret API keys
 fi
 
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH";
@@ -22,10 +20,10 @@ echo "TRAVIS_PULL_REQUEST_BRANCH: $TRAVIS_PULL_REQUEST_BRANCH";
 REQUEST_FILES=$(git diff --diff-filter=A --name-only $TRAVIS_BRANCH | cat | grep "^requests\/[^\/]*$")
 
 # Altered files in tool directories (eg. galaxy-aust-staging) written to by jenkins
-JENKINS_CONTROLLED_FILES=$(git diff --name-only $TRAVIS_BRANCH | cat  | grep "^(?:\$STAGING_DIR\/|PRODUCTION_DIR\/).*/")
+JENKINS_CONTROLLED_FILES=$(git diff --name-only $TRAVIS_BRANCH | cat  | grep "^(?:\$STAGING_TOOL_DIR\/|PRODUCTION_TOOL_DIR\/).*/")
 
 if [ $JENKINS_CONTROLLED_FILES ]; then
-  echo "Files within $PRODUCTION_DIR or $STAGING_DIR are written by Jenkins and cannot be altered";
+  echo "Files within $PRODUCTION_TOOL_DIR or $STAGING_TOOL_DIR are written by Jenkins and cannot be altered";
   exit 1;
 fi
 

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -10,33 +10,29 @@ if [ ! $TRAVIS_PULL_REQUEST ] && [ ! "$@" = "local" ]; then
   exit 0;
 fi
 
-if [ "$@" = "local" ]; then
+if [[ "$@" = "local" ]]; then
   TRAVIS_BRANCH=master
   export $(cat .env)
 fi
 
-# check the range of the commit input_file_paths
-echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
-echo "TRAVIS_PULL_REQUEST_BRANCH: $TRAVIS_PULL_REQUEST_BRANCH"
+echo "TRAVIS_BRANCH: $TRAVIS_BRANCH";
+echo "TRAVIS_PULL_REQUEST_BRANCH: $TRAVIS_PULL_REQUEST_BRANCH";
 
+# Added files in requests directory
 REQUEST_FILES=$(git diff --diff-filter=A --name-only $TRAVIS_BRANCH | cat | grep "^requests\/[^\/]*$")
+
+# Altered files in tool directories (eg. galaxy-aust-staging) written to by jenkins
 JENKINS_CONTROLLED_FILES=$(git diff --name-only $TRAVIS_BRANCH | cat  | grep "^(?:\$STAGING_DIR\/|PRODUCTION_DIR\/).*/")
 
 if [ $JENKINS_CONTROLLED_FILES ]; then
-  echo 'Files within $PRODUCTION_DIR or $STAGING_DIR are written by Jenkins and cannot be altered';
+  echo "Files within $PRODUCTION_DIR or $STAGING_DIR are written by Jenkins and cannot be altered";
   exit 1;
 fi
 
-echo $REQUEST_FILES
 if [ ! "$REQUEST_FILES" ]; then
-  echo 'No changed files in requests directory: there are no tests for this scenario';
+  echo "No changed files in requests directory: there are no tests for this scenario";
   exit 0;
 fi
 
-FILE_ARGS=$REQUEST_FILES
-if [ ! -f $REQUEST_FILES ]; then
-  FILE_ARGS=$(tr "\n" " " < $REQUEST_FILES)
-fi
-
 # pass the requests file paths to a python script that checks the input files
-python .travis/check_files.py -f $FILE_ARGS --staging_url $STAGING_URL --staging_api_key $STAGING_API_KEY --production_url $PRODUCTION_URL --production_api_key $PRODUCTION_API_KEY
+python .travis/check_files.py -f $REQUEST_FILES --staging_url $STAGING_URL --staging_api_key $STAGING_API_KEY --production_url $PRODUCTION_URL --production_api_key $PRODUCTION_API_KEY

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -1,0 +1,38 @@
+STAGING_DIR='galaxy-cat'  # TODO: when using this in production swap this to 'galaxy-aust-staging' (commented out below)
+PRODUCTION_DIR='cat-dev'  # TODO: when using this in production swap this to 'usegalaxy.org.au' (commented out below)
+
+# STAGING_DIR='galaxy-aust-staging'
+# PRODUCTION_DIR='usegalaxy.org.au'
+
+if [ ! $TRAVIS_PULL_REQUEST ] && [ ! "$@" = "local" ]; then
+  exit 0;
+fi
+
+# check the range of the commit input_file_paths
+echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
+echo "TRAVIS_PULL_REQUEST_BRANCH: $TRAVIS_PULL_REQUEST_BRANCH"
+CHANGED_FILES=$(git diff --diff-filter=A --name-only $TRAVIS_BRANCH)
+echo ________________
+echo "git diff --name-only --diff-filter=A $TRAVIS_BRANCH"
+echo $CHANGED_FILES
+echo ________________
+REQUEST_FILES=$(echo $CHANGED_FILES | grep "^requests\/[^\/]*$")
+JENKINS_CONTROLLED_FILES=$(echo $CHANGED_FILES | grep "^(?:\$STAGING_DIR\/|PRODUCTION_DIR\/).*/")
+
+if [ $JENKINS_CONTROLLED_FILES ]; then
+  echo 'Files within $PRODUCTION_DIR or $STAGING_DIR are written by Jenkins and cannot be altered';
+  exit 1;
+fi
+
+if [ ! $REQUEST_FILES ]; then
+  echo 'No changed files in requests directory: there are no tests for this scenario';
+  exit 0;
+fi
+
+FILE_ARGS=$REQUEST_FILES
+if [ ! -f $REQUESTS_FILES ]; then
+  FILE_ARGS=$(tr "\n" " " < $REQUESTS_FILES)
+fi
+
+# pass the requests file paths to a python script that checks the yml
+python .travis/travis_check_files.py -f $FILE_ARGS

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -1,3 +1,5 @@
+STAGING_URL='https://galaxy-cat.genome.edu.au'  # TODO: when using this in production swap this to 'galaxy-aust-staging' (commented out below)
+PRODUCTION_URL='https://cat-dev.genome.edu.au'  # TODO: when using this in production swap this to 'usegalaxy.org.au' (commented out below)
 STAGING_DIR='galaxy-cat'  # TODO: when using this in production swap this to 'galaxy-aust-staging' (commented out below)
 PRODUCTION_DIR='cat-dev'  # TODO: when using this in production swap this to 'usegalaxy.org.au' (commented out below)
 
@@ -8,31 +10,33 @@ if [ ! $TRAVIS_PULL_REQUEST ] && [ ! "$@" = "local" ]; then
   exit 0;
 fi
 
+if [ "$@" = "local" ]; then
+  TRAVIS_BRANCH=master
+  export $(cat .env)
+fi
+
 # check the range of the commit input_file_paths
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
 echo "TRAVIS_PULL_REQUEST_BRANCH: $TRAVIS_PULL_REQUEST_BRANCH"
-CHANGED_FILES=$(git diff --diff-filter=A --name-only $TRAVIS_BRANCH)
-echo ________________
-echo "git diff --name-only --diff-filter=A $TRAVIS_BRANCH"
-echo $CHANGED_FILES
-echo ________________
-REQUEST_FILES=$(echo $CHANGED_FILES | grep "^requests\/[^\/]*$")
-JENKINS_CONTROLLED_FILES=$(echo $CHANGED_FILES | grep "^(?:\$STAGING_DIR\/|PRODUCTION_DIR\/).*/")
+
+REQUEST_FILES=$(git diff --diff-filter=A --name-only $TRAVIS_BRANCH | cat | grep "^requests\/[^\/]*$")
+JENKINS_CONTROLLED_FILES=$(git diff --name-only $TRAVIS_BRANCH | cat  | grep "^(?:\$STAGING_DIR\/|PRODUCTION_DIR\/).*/")
 
 if [ $JENKINS_CONTROLLED_FILES ]; then
   echo 'Files within $PRODUCTION_DIR or $STAGING_DIR are written by Jenkins and cannot be altered';
   exit 1;
 fi
 
-if [ ! $REQUEST_FILES ]; then
+echo $REQUEST_FILES
+if [ ! "$REQUEST_FILES" ]; then
   echo 'No changed files in requests directory: there are no tests for this scenario';
   exit 0;
 fi
 
 FILE_ARGS=$REQUEST_FILES
-if [ ! -f $REQUESTS_FILES ]; then
-  FILE_ARGS=$(tr "\n" " " < $REQUESTS_FILES)
+if [ ! -f $REQUEST_FILES ]; then
+  FILE_ARGS=$(tr "\n" " " < $REQUEST_FILES)
 fi
 
-# pass the requests file paths to a python script that checks the yml
-python .travis/travis_check_files.py -f $FILE_ARGS
+# pass the requests file paths to a python script that checks the input files
+python .travis/check_files.py -f $FILE_ARGS --staging_url $STAGING_URL --staging_api_key $STAGING_API_KEY --production_url $PRODUCTION_URL --production_api_key $PRODUCTION_API_KEY

--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -7,20 +7,21 @@ export BUILD_NUMBER="$BUILD_NUMBER"
 export INSTALL_ID="$(date '+%Y%m%d%H%M%S')" # this will do for now, could incorporate jenkins build ID or git commit hash
 export LOG_DIR=~/galaxy_tool_automation
 export BASH_V="$(echo ${BASH_VERSION} | head -c 1)" # this will be "4" if the bash version is 4.x, empty otherwise
+export $(cat .env); # Environment variables such as galaxy URLs
 
 SUPPLIED_ARGS="$@"
 
 # Switch to allow the script to be run locally or remotely at stages of development
-# if RUN_LOCALLY is true, the script will only run where an .env file is present
-# The .env file is necessary for loading the API keys outside of the jenkins environment
+# if RUN_LOCALLY is true, the script will only run where a .secret.env file is present
+# The .secret.env file is necessary for loading the API keys outside of the jenkins environment
 RUN_LOCALLY=0 # (1) Disable script on jenkins (0) run script on jenkins
 export LOCAL_ENV=0
 RUN=1 # true=1, false=0
-ENV_FILE=.env
+ENV_FILE=.secret.env
 if [ -f "$ENV_FILE" ]; then
     export LOCAL_ENV=1
     export LOG_DIR=logs
-    export $(cat .env)
+    export $(cat $ENV_FILE)
     # GIT_COMMIT and GIT_PREVIOUS_COMMIT are supplied by Jenkins
     # Use HEAD and HEAD~1 when running locally
     GIT_PREVIOUS_COMMIT=HEAD~1;

--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -1,0 +1,71 @@
+#! /bin/bash
+chmod +x jenkins/webhook_install_tools.sh
+
+export GIT_COMMIT="$GIT_COMMIT"
+export GIT_PREVIOUS_COMMIT="$GIT_PREVIOUS_COMMIT"
+export BUILD_NUMBER="$BUILD_NUMBER"
+export INSTALL_ID="$(date '+%Y%m%d%H%M%S')" # this will do for now, could incorporate jenkins build ID or git commit hash
+export LOG_DIR=~/galaxy_tool_automation
+export BASH_V="$(echo ${BASH_VERSION} | head -c 1)" # this will be "4" if the bash version is 4.x, empty otherwise
+
+# Switch to allow the script to be run locally or remotely at stages of development
+# if RUN_LOCALLY is true, the script will only run where an .env file is present
+RUN_LOCALLY=0 # (1) Disable script on jenkins (0) run script on jenkins
+export LOCAL_ENV=0
+RUN=1 # true=1, false=0
+FILE=.env
+if [ -f "$FILE" ]; then
+		export LOCAL_ENV=1
+		export LOG_DIR=logs
+		export $(cat .env)
+		GIT_PREVIOUS_COMMIT=HEAD~1
+		GIT_COMMIT=HEAD
+		if [ $@ ]; then
+			# Allow filename to be provided as argument if running locally
+			export SUPPLIED_FILENAME=$@;
+		fi
+    echo 'Script running in local enviroment';
+else
+		echo 'Script running on jenkins server';
+		if [ $RUN_LOCALLY = 1 ]; then
+				echo 'Skipping installation as RUN_LOCALLY is set to 1 (true)';
+				RUN=0;
+		fi
+fi
+
+if [ ! -d LOG_DIR ]; then
+	mkdir $LOG_DIR
+fi
+export LOG_FILE="$LOG_DIR/webhook_tool_installation_$INSTALL_ID"
+
+jenkins_tool_installation() {
+	# First check whether changed files are in the path of tool requests, that is within the requests folder but not within
+	# any subfolders of requests.  If so, we run the install script.  If not we exit.
+	export REQUESTS_DIFF=$(git diff --name-only --diff-filter=A $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep "^requests\/[^\/]*$")
+
+	if [ ! $REQUESTS_DIFF ]; then
+		if [ $LOCAL_ENV = 1 ] && [ $SUPPLIED_FILENAME ]; then # if running locally, allow a filename argument
+			echo Running locally, installing $SUPPLIED_FILENAME;
+			export REQUESTS_DIFF=$SUPPLIED_FILENAME;
+		else
+			echo 'No added files in requests folder, no tool installation required';
+			exit 0;
+		fi
+	else
+		echo 'Tools from the following files will be installed';
+		echo $REQUESTS_DIFF;
+	fi
+
+	echo Saving output to $LOG_FILE
+	if [ $LOCAL_ENV = 0 ]; then
+		bash jenkins/webhook_install_tools.sh &> $LOG_FILE
+		cat $LOG_FILE
+	else
+		# Do not save a log file when running locally
+		bash jenkins/webhook_install_tools.sh
+	fi
+}
+
+if [ $RUN = 1 ]; then
+	jenkins_tool_installation
+fi

--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -8,64 +8,73 @@ export INSTALL_ID="$(date '+%Y%m%d%H%M%S')" # this will do for now, could incorp
 export LOG_DIR=~/galaxy_tool_automation
 export BASH_V="$(echo ${BASH_VERSION} | head -c 1)" # this will be "4" if the bash version is 4.x, empty otherwise
 
+SUPPLIED_ARGS="$@"
+
 # Switch to allow the script to be run locally or remotely at stages of development
 # if RUN_LOCALLY is true, the script will only run where an .env file is present
+# The .env file is necessary for loading the API keys outside of the jenkins environment
 RUN_LOCALLY=0 # (1) Disable script on jenkins (0) run script on jenkins
 export LOCAL_ENV=0
 RUN=1 # true=1, false=0
-FILE=.env
-if [ -f "$FILE" ]; then
-		export LOCAL_ENV=1
-		export LOG_DIR=logs
-		export $(cat .env)
-		GIT_PREVIOUS_COMMIT=HEAD~1
-		GIT_COMMIT=HEAD
-		if [ $@ ]; then
-			# Allow filename to be provided as argument if running locally
-			export SUPPLIED_FILENAME=$@;
-		fi
-    echo 'Script running in local enviroment';
+ENV_FILE=.env
+if [ -f "$ENV_FILE" ]; then
+    export LOCAL_ENV=1
+    export LOG_DIR=logs
+    export $(cat .env)
+    # GIT_COMMIT and GIT_PREVIOUS_COMMIT are supplied by Jenkins
+    # Use HEAD and HEAD~1 when running locally
+    GIT_PREVIOUS_COMMIT=HEAD~1;
+    GIT_COMMIT=HEAD;
+    echo "Script running in local enviroment";
 else
-		echo 'Script running on jenkins server';
-		if [ $RUN_LOCALLY = 1 ]; then
-				echo 'Skipping installation as RUN_LOCALLY is set to 1 (true)';
-				RUN=0;
-		fi
+    echo "Script running on jenkins server";
+    if [ $RUN_LOCALLY = 1 ]; then
+        echo "Skipping installation as RUN_LOCALLY is set to 1 (true)";
+        RUN=0;
+    fi
 fi
 
-if [ ! -d LOG_DIR ]; then
-	mkdir $LOG_DIR
-fi
+[ -d LOG_DIR ] || mkdir $LOG_DIR;ß
 export LOG_FILE="$LOG_DIR/webhook_tool_installation_$INSTALL_ID"
 
 jenkins_tool_installation() {
-	# First check whether changed files are in the path of tool requests, that is within the requests folder but not within
-	# any subfolders of requests.  If so, we run the install script.  If not we exit.
-	export REQUESTS_DIFF=$(git diff --name-only --diff-filter=A $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep "^requests\/[^\/]*$")
+  # First check whether changed files are in the path of tool requests, that is within the requests folder but not within
+  # any subfolders of requests.  If so, we run the install script.  If not we exit.
+  REQUESTS_DIFF=$(git diff --name-only --diff-filter=A $GIT_PREVIOUS_COMMIT $GIT_COMMIT | cat | grep "^requests\/[^\/]*$")
 
-	if [ ! $REQUESTS_DIFF ]; then
-		if [ $LOCAL_ENV = 1 ] && [ $SUPPLIED_FILENAME ]; then # if running locally, allow a filename argument
-			echo Running locally, installing $SUPPLIED_FILENAME;
-			export REQUESTS_DIFF=$SUPPLIED_FILENAME;
-		else
-			echo 'No added files in requests folder, no tool installation required';
-			exit 0;
-		fi
-	else
-		echo 'Tools from the following files will be installed';
-		echo $REQUESTS_DIFF;
-	fi
+  # Arrange git diff into string "file1 file2 .. fileN"
+  FILE_ARGS=$REQUESTS_DIFF
+  if [[ "$REQUESTS_DIFF" == *$'\n'* ]]; then
+    FILE_ARGS=$(echo $REQUESTS_DIFF | tr "\n" " ")
+  fi
 
-	echo Saving output to $LOG_FILE
-	if [ $LOCAL_ENV = 0 ]; then
-		bash jenkins/webhook_install_tools.sh &> $LOG_FILE
-		cat $LOG_FILE
-	else
-		# Do not save a log file when running locally
-		bash jenkins/webhook_install_tools.sh
-	fi
+  if [ $LOCAL_ENV = 1 ] && [ $SUPPLIED_ARGS ]; then # if running locally, allow a filename argument
+    echo Running locally, installing $SUPPLIED_ARGS;
+    FILE_ARGS=$SUPPLIED_ARGS;
+  fi
+
+  export FILE_ARGS=$FILE_ARGS
+
+  if [[ ! $REQUESTS_DIFF ]]; then
+    # Exit early and do not write a log if the commit does not contain request files
+    echo "No added files in requests folder, no tool installation required";
+    exit 0;
+  else
+    echo "Tools from the following files will be installed";
+    echo $REQUESTS_DIFF;
+  fi
+
+  echo "Saving output to $LOG_FILE"
+  if [ $LOCAL_ENV = 0 ]; then
+    bash jenkins/webhook_install_tools.sh &> $LOG_FILE
+    cat $LOG_FILE
+  else
+    # Do not save a log file when running locally
+    bash jenkins/webhook_install_tools.sh
+
+  fi
 }
 
 if [ $RUN = 1 ]; then
-	jenkins_tool_installation
+  jenkins_tool_installation
 fi

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -294,7 +294,10 @@ test_tool() {
   fi
 
   # Special case: If package is already installed on staging we skip tests and install on production
-  [ $SERVER = "STAGING" ] && [ $INSTALLATION_STATUS = "Skipped" ] && { echo "Skipping testing on $STAGING_URL"; return 0 }
+  if [ $SERVER = "STAGING" ] && [ $INSTALLATION_STATUS = "Skipped" ]; then
+    echo "Skipping testing on $STAGING_URL";
+    return 0;
+  fi
 
   TEST_LOG='tmp/test_log.txt'
   rm -f $TEST_LOG ||:;  # delete if it does not exist

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -1,9 +1,5 @@
 #! /bin/bash
 
-STAGING_URL=https://galaxy-cat.genome.edu.au
-PRODUCTION_URL=https://cat-dev.genome.edu.au
-STAGING_TOOL_DIR=galaxy-cat
-PRODUCTION_TOOL_DIR=cat-dev
 AUTOMATED_TOOL_INSTALLATION_LOG='automated_tool_installation_log.tsv'; # version controlled
 LOG_HEADER="Jenkins Build Number\tInstall ID\tDate (UTC)\tStatus\tFailing Step\tStaging tests passed\tProduction tests passed\tName\tOwner\tRequested Revision\tInstalled Revision\tSection Label\tTool Shed URL\tLog Path"
 

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -139,6 +139,7 @@ install_tools() {
 
 		echo -e "\nPushing Changes to github"
 		git commit -a -m "$COMMIT_MESSAGE"
+		git pull;
 		git push
 		echo -e "\nDone"
 	fi
@@ -172,12 +173,10 @@ test_tool() {
 	echo
 	if [ $BASH_V = 4 ]; then
 		# normal regex
-		[[ $(cat $INSTALL_LOG) =~ "Passed tool tests \((\d+)\)" ]];
+		[[ $(cat $TEST_LOG) =~ "Passed tool tests \(([0-9])\)" ]];
 		TESTS_PASSED="${BASH_REMATCH[1]}"
-		[[ $(cat $INSTALL_LOG) =~ "Failed tool tests \((\d+)\)" ]];
+		[[ $(cat $TEST_LOG) =~ "Failed tool tests \(([0-9])\)" ]];
 		TESTS_FAILED="${BASH_REMATCH[1]}"
-		echo $TESTS_PASSED
-		echo $TESTS_FAILED
 	else
 		# resort to python helper
 		TESTS_PASSED="$(python scripts/first_match_regex.py -p 'Passed tool tests \((\d+)\)' $TEST_LOG)"

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -1,0 +1,351 @@
+#! /bin/bash
+
+STAGING_URL=https://galaxy-cat.genome.edu.au ##
+PRODUCTION_URL=https://cat-dev.genome.edu.au
+STAGING_TOOL_DIR=galaxy-cat
+PRODUCTION_TOOL_DIR=cat-dev
+AUTOMATED_TOOL_INSTALLATION_LOG='automated_tool_installation_log.tsv'; # version controlled
+LOG_HEADER="Jenkins Build Number\tInstall ID\tLog Path\tStatus\tFailing Step\tName"
+
+install_tools() {
+	echo Running automated tool installation script
+	echo --------------------------
+	echo STAGING_URL = $STAGING_URL
+	echo PRODUCTION_URL = $PRODUCTION_URL
+	echo STAGING_TOOL_DIR = $STAGING_TOOL_DIR
+	echo PRODUCTION_TOOL_DIR = $PRODUCTION_TOOL_DIR
+
+	# Jenkins build number
+	echo BUILD_NUMBER = $BUILD_NUMBER
+	echo INSTALL_ID = $INSTALL_ID
+	echo GIT_COMMIT = $GIT_COMMIT
+	echo GIT_PREVIOUS_COMMIT = $GIT_PREVIOUS_COMMIT
+	echo -------------------------------
+
+	# Virtual environment in build directory has ephemeris and bioblend installed.
+	# If this script is being run for the first time we will need to set up the
+	# virtual environment
+	if [ $LOCAL_ENV = 0 ]; then
+		VIRTUALENV="../.venv"
+		if [ ! -d $VIRTUALENV ]; then
+			echo "creating virtual environment";
+		        virtualenv $VIRTUALENV;
+			cd ..
+			pip install ephemeris
+			pip install bioblend
+			cd workspace
+		fi
+		. $VIRTUALENV/bin/activate
+	fi
+
+	# Ensure log file exists, create it if not
+	if [ ! -f $AUTOMATED_TOOL_INSTALLATION_LOG ]; then
+		echo -e $LOG_HEADER > $AUTOMATED_TOOL_INSTALLATION_LOG;
+		git add $AUTOMATED_TOOL_INSTALLATION_LOG; # this has to be a tracked file
+	fi
+
+	# Arrange git diff into string "file1 file2 .. fileN"
+	FILE_ARGS=$REQUESTS_DIFF
+	if [ ! -f $REQUESTS_DIFF ]; then
+		FILE_ARGS=$(tr "\n" " " < $REQUESTS_DIFF)
+	fi
+
+	if [ $LOCAL_ENV = 0 ]; then
+		# enable pushing to github.  there is almost certainly a better way to do this
+		git remote set-url origin git@github.com:cat-bro/usegalaxy-au-tools.git
+		eval `ssh-agent`
+		ssh-add ~/.ssh/github_catbro_au_tools.rsa
+		# make sure we are not in detached head state by checking out master
+		git checkout master
+		git pull
+	fi
+
+	TOOL_FILE_PATH="requests/pending/$INSTALL_ID/"
+	mkdir -p $TOOL_FILE_PATH
+
+	# split requests into individual yaml files in requests/pending
+	# one file per unique revision so that installation can be run sequentially and
+	# failure of one installation will not affect the others
+	python scripts/organise_request_files.py -f $FILE_ARGS -o $TOOL_FILE_PATH
+
+	NUM_TOOLS_TO_INSTALL=$(ls $TOOL_FILE_PATH | wc -l)
+	INSTALLED_TOOL_COUNTER=0
+
+	for FILE_NAME in $(ls $TOOL_FILE_PATH)
+	do
+		TOOL_FILE=$TOOL_FILE_PATH$FILE_NAME
+		TOOL_REF=$(echo $FILE_NAME | cut -d'.' -f 1)
+		TOOL_NAME=$(echo $(grep -oE "name: (\w+)" "$TOOL_FILE") | awk '{print $2}');
+
+		echo -e "\nInstalling $TOOL_NAME from file $TOOL_FILE"
+		cat $TOOL_FILE
+
+		{
+			echo -e "\nStep (1): Installing $TOOL_NAME on staging server";
+			install_tool "STAGING" $TOOL_FILE
+		} && {
+			echo -e "\nStep (2): Testing $TOOL_NAME on staging server";
+			test_tool "STAGING" $TOOL_FILE
+		} && {
+			echo -e "\nStep (3): Installing $TOOL_NAME on production server";
+			install_tool "PRODUCTION" $TOOL_FILE
+		} && {
+			echo -e "\nStep (4): Testing $TOOL_NAME on production server";
+			test_tool "PRODUCTION" $TOOL_FILE
+		}
+	done
+
+	echo "$INSTALLED_TOOL_COUNTER out of $NUM_TOOLS_TO_INSTALL tools installed."
+	if [ ! "$LOG_ENTRY" ]; then
+		echo "WARNING: No log entry stored";
+	else
+		echo "Writing entry to $AUTOMATED_TOOL_INSTALLATION_LOG"
+		echo "=================================================="
+		echo -e $LOG_HEADER
+		echo -e $LOG_ENTRY
+		echo "=================================================="
+		echo -e $LOG_ENTRY >> $AUTOMATED_TOOL_INSTALLATION_LOG;
+
+		update_tool_list "STAGING"
+		update_tool_list "PRODUCTION"
+
+		# Push changes to github
+		# Add any new tool list files that have been created.
+		for $YML_FILE in $(ls $STAGING_TOOL_DIR)                                                                                                                                                 catherine@catherines-mbp
+	  do
+	    git add $STAGING_TOOL_DIR/$YML_FILE ||:
+	  done
+		for $YML_FILE in $(ls $PRODUCTION_TOOL_DIR)                                                                                                                                                 catherine@catherines-mbp
+	  do
+	    git add $PRODUCTION_TOOL_DIR/$YML_FILE ||:
+	  done
+
+		for FILE_NAME in $(ls $TOOL_FILE_PATH)
+		do
+			git add $TOOL_FILE_PATH$FILE_NAME
+		done
+		for FILE_NAME in $REQUESTS_DIFF
+		do
+			git rm $FILE_NAME
+		done
+
+		# For the benefit of development log ALL git changes, per file
+		for filepath in $(git diff --name-only | cat)
+		do
+			git diff $filepath | cat
+			echo
+		done
+		COMMIT_MESSAGE="Jenkins build $BUILD_NUMBER."
+
+		echo -e "\nPushing Changes to github"
+		git commit -a -m "$COMMIT_MESSAGE"
+		git push
+		echo -e "\nDone"
+	fi
+}
+
+# TODO all calls to shed-tools need to catch errors
+
+test_tool() {
+	# Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path
+	TOOL_FILE="$2"
+	SERVER="$1"
+	if [ $SERVER = "STAGING" ]; then
+		API_KEY=$STAGING_API_KEY
+		URL=$STAGING_URL
+		TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_staging_test.json
+		STEP="Staging Testing"
+	elif [ $SERVER = "PRODUCTION" ]; then
+		API_KEY=$PRODUCTION_API_KEY
+		URL=$PRODUCTION_URL
+		TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_production_test.json
+		STEP="Production Testing"
+	else
+		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+		return 1
+	fi
+
+	TEST_LOG='tmp/test_log.txt'
+	rm -f $TEST_LOG ||:;  # delete if it does not exist
+
+	command="shed-tools test -g $URL -a $API_KEY -t $TOOL_FILE --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
+	echo "${command/$API_KEY/<API_KEY>}"
+	$command || return 1
+	echo
+	if [ $BASH_V = 4 ]; then
+		# normal regex
+		[[ $(cat $INSTALL_LOG) =~ "Passed tool tests \((\d+)\)" ]];
+		TESTS_PASSED="${BASH_REMATCH[1]}"
+		[[ $(cat $INSTALL_LOG) =~ "Failed tool tests \((\d+)\)" ]];
+		TESTS_FAILED="${BASH_REMATCH[1]}"
+		echo $TESTS_PASSED
+		echo $TESTS_FAILED
+	else
+		# resort to python helper
+		TESTS_PASSED="$(python scripts/first_match_regex.py -p 'Passed tool tests \((\d+)\)' $TEST_LOG)"
+		TESTS_FAILED="$(python scripts/first_match_regex.py -p 'Failed tool tests \((\d+)\)' $TEST_LOG)"
+	fi
+	if [ $TESTS_FAILED = 0 ]; then
+		if [ $TESTS_PASSED = 0 ]; then
+			echo "WARNING: There are no tests for $TOOL_NAME at revision $INSTALLED_REVISION.  Proceeding as none have failed.";
+		else
+			echo "All tests have passed for $TOOL_NAME at revision $INSTALLED_REVISION on $URL.";
+		fi
+		if [ "$SERVER" = "PRODUCTION" ]; then
+			unset STEP
+			log_row "Success"
+			exit_installation 0 ""
+			return 0
+		fi
+		echo -e "\nSuccessfully installed $TOOL_NAME on $URL\n";
+	else
+		echo "Failed to install: Winding back installation as some tests have failed.";
+		echo "Uninstalling on $URL";
+		python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
+		if [ $SERVER = "PRODUCTION" ]; then
+			# also uninstall on staging
+			echo "Uninstalling on $STAGING_URL";
+			python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
+		fi
+		log_row "Tests failed"
+		exit_installation 1 ""
+		return 1
+	fi
+}
+
+install_tool() {
+	# Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path, $3 = repeat (default 1)
+	if [ "$3" ]; then
+		REPEAT="$3";
+	else
+		REPEAT=1
+	fi
+
+	TOOL_FILE="$2"
+	SERVER="$1"
+	if [ $SERVER = "STAGING" ]; then
+		API_KEY=$STAGING_API_KEY
+		URL=$STAGING_URL
+		STEP="Staging Installation"
+	elif [ $SERVER = "PRODUCTION" ]; then
+		API_KEY=$PRODUCTION_API_KEY
+		URL=$PRODUCTION_URL
+		STEP="Production Installation"
+	else
+		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+		return 1
+	fi
+
+	INSTALL_LOG='tmp/install_log.txt'
+	rm -f $INSTALL_LOG ||:;  # delete if it does not exist
+
+	# Ephemeris install script
+	command="shed-tools install -g $URL -a $API_KEY -t $TOOL_FILE -v --log_file $INSTALL_LOG"
+	echo "${command/$API_KEY/<API_KEY>}"; # substitute API_KEY for printing
+	$command || return 1
+
+	# Capture the status (Installed/Skipped/Errored), name and revision hash from ephemeris output
+	if [ $BASH_V = 4 ]; then
+		PATTERN="(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]"
+		[[ $(cat $INSTALL_LOG) =~ $PATTERN ]];
+		INSTALLATION_STATUS="${BASH_REMATCH[1]}";
+		INSTALLED_NAME="${BASH_REMATCH[2]}";
+		INSTALLED_REVISION="${BASH_REMATCH[3]}";
+		echo $INSTALLATION_STATUS
+		echo $INSTALLED_NAME
+		echo $INSTALLED_REVISION
+	else # the regex above does not work on my local machine (Mac), hence this python workaround
+		SHED_TOOLS_VALUES=($(python scripts/first_match_regex.py -p "(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]" $INSTALL_LOG));
+	fi
+	if [ $SHED_TOOLS_VALUES ]; then
+		INSTALLATION_STATUS="${SHED_TOOLS_VALUES[0]}";
+		INSTALLED_NAME="${SHED_TOOLS_VALUES[1]}";
+		INSTALLED_REVISION="${SHED_TOOLS_VALUES[2]}";
+	fi
+	# If all three values are not null, proceed only if status is Installed,
+	# write log entry and leave otherwise
+	if [ "$INSTALLATION_STATUS" ] && [ "$INSTALLED_NAME" ] && [ "$INSTALLED_REVISION" ]; then
+		if [ ! $INSTALLATION_STATUS = 'Installed' ]; then
+			if [ $INSTALLATION_STATUS = "Errored" ]; then
+				# The tool may or may not be installed according to the API, so it needs to be
+				# uninstalled with bioblend
+				echo "Installation error.  Uninstalling $TOOL_NAME on $URL";
+				python scripts/uninstall_tools.py -g $URL -a $API_KEY -n "$INSTALLED_NAME@$INSTALLED_REVISION";
+				if [ $SERVER = "PRODUCTION" ]; then
+					# also uninstall on staging
+					echo "Uninstalling $TOOL_NAME on $STAGING_URL";
+					python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
+				fi
+				echo "Halting unsuccessful installation";
+			elif [ $INSTALLATION_STATUS = "Skipped" ]; then
+				# Note that linting process should prevent this scenario
+				echo "Package appears to be already installed on $URL";
+			fi
+			log_row $INSTALLATION_STATUS
+			exit_installation 1 ""
+			# TODO: Should files be moved elsewhere?
+			return 1;
+		else
+			if [ ! "$TOOL_NAME" = "$INSTALLED_NAME" ]; then
+				# Sanity check.  If these are not the same name, uninstall and abandon process with 'Script error'
+				python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
+				log_row "Script Error"
+				exit_installation 1 ""
+				return 1
+			fi
+		fi
+		else
+			# TODO what if this is production server?  wind back staging installation?
+			log_row "Script error"
+			exit_installation 1 "Could not verify installation from shed-tools output."
+			return 1
+	fi
+}
+
+log_row() {
+	# 'Jenkins Build Number\tInstall ID\tLog Path\tStatus\tFailing Step\tName'
+	# TODO: What are relevant log values?  Owner.  Revision.  Section.  Toolshed URL. Start time.  Finish time.  Elapsed time.
+	STATUS="$1"
+	if [ "$LOG_ENTRY" ]; then
+		LOG_ENTRY="$LOG_ENTRY\n";	# If log entry has content, add new line before new content
+	fi
+	LOG_ROW="$BUILD_NUMBER\t$INSTALL_ID\t$LOG_FILE\t$STATUS\t$STEP\t$TOOL_NAME"
+  LOG_ENTRY="$LOG_ENTRY$LOG_ROW"
+	# echo -e $LOG_ROW; # Need to print this values?  Store them in multiD array? What if script stops in the middle?
+}
+
+exit_installation() {
+	unset OUTCOME
+	FAILED="$1"; # 0 for success, 1 for failure
+	MESSAGE="$2";
+	if [ "$FAILED" = "1" ]; then
+		OUTCOME="Failed to install"
+	elif [ "$FAILED" = "0" ]; then
+		OUTCOME="Successfully installed"
+		INSTALLED_TOOL_COUNTER=$((INSTALLED_TOOL_COUNTER+1))
+	fi
+	echo -e "\n$OUTCOME $TOOL_NAME." $MESSAGE
+}
+
+update_tool_list() {
+	SERVER="$1"
+	if [ $SERVER = "STAGING" ]; then
+		API_KEY=$STAGING_API_KEY
+		URL=$STAGING_URL
+		TOOL_DIR=$STAGING_TOOL_DIR
+	elif [ $SERVER = "PRODUCTION" ]; then
+		API_KEY=$PRODUCTION_API_KEY
+		URL=$PRODUCTION_URL
+		TOOL_DIR=$PRODUCTION_TOOL_DIR
+	else
+		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+		return 1
+	fi
+
+	TMP_TOOL_FILE=tmp/tool_list.yml
+	rm -f $TMP_TOOL_FILE ||:; # remove file if it exists
+	get-tool-list -g $URL -a $API_KEY -o $TMP_TOOL_FILE --get_data_managers
+	python scripts/split_tool_yml.py -i $TMP_TOOL_FILE -o $TOOL_DIR; # Simon's script
+}
+
+install_tools

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-STAGING_URL=https://galaxy-cat.genome.edu.au ##
+STAGING_URL=https://galaxy-cat.genome.edu.au
 PRODUCTION_URL=https://cat-dev.genome.edu.au
 STAGING_TOOL_DIR=galaxy-cat
 PRODUCTION_TOOL_DIR=cat-dev

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -111,13 +111,13 @@ install_tools() {
 
 		# Push changes to github
 		# Add any new tool list files that have been created.
-		for $YML_FILE in $(ls $STAGING_TOOL_DIR)                                                                                                                                                 catherine@catherines-mbp
+		for YML_FILE in $(ls $STAGING_TOOL_DIR)
 	  do
-	    git add $STAGING_TOOL_DIR/$YML_FILE ||:
+	    git add $STAGING_TOOL_DIR/$YML_FILE
 	  done
-		for $YML_FILE in $(ls $PRODUCTION_TOOL_DIR)                                                                                                                                                 catherine@catherines-mbp
+		for YML_FILE in $(ls $PRODUCTION_TOOL_DIR)
 	  do
-	    git add $PRODUCTION_TOOL_DIR/$YML_FILE ||:
+	    git add $PRODUCTION_TOOL_DIR/$YML_FILE
 	  done
 
 		for FILE_NAME in $(ls $TOOL_FILE_PATH)
@@ -143,8 +143,6 @@ install_tools() {
 		echo -e "\nDone"
 	fi
 }
-
-# TODO all calls to shed-tools need to catch errors
 
 test_tool() {
 	# Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path
@@ -290,7 +288,7 @@ install_tool() {
 				# Sanity check.  If these are not the same name, uninstall and abandon process with 'Script error'
 				python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
 				log_row "Script Error"
-				exit_installation 1 ""
+				exit_installation 1 "Unexpected value for name of installed tool."
 				return 1
 			fi
 		fi

--- a/jenkins/webhook_install_tools.sh
+++ b/jenkins/webhook_install_tools.sh
@@ -5,344 +5,387 @@ PRODUCTION_URL=https://cat-dev.genome.edu.au
 STAGING_TOOL_DIR=galaxy-cat
 PRODUCTION_TOOL_DIR=cat-dev
 AUTOMATED_TOOL_INSTALLATION_LOG='automated_tool_installation_log.tsv'; # version controlled
-LOG_HEADER="Jenkins Build Number\tInstall ID\tLog Path\tStatus\tFailing Step\tName"
+LOG_HEADER="Jenkins Build Number\tInstall ID\tDate (UTC)\tStatus\tFailing Step\tStaging tests passed\tProduction tests passed\tName\tOwner\tRequested Revision\tInstalled Revision\tSection Label\tTool Shed URL\tLog Path"
 
 install_tools() {
-	echo Running automated tool installation script
-	echo --------------------------
-	echo STAGING_URL = $STAGING_URL
-	echo PRODUCTION_URL = $PRODUCTION_URL
-	echo STAGING_TOOL_DIR = $STAGING_TOOL_DIR
-	echo PRODUCTION_TOOL_DIR = $PRODUCTION_TOOL_DIR
+  echo Running automated tool installation script
+  echo --------------------------
+  echo STAGING_URL = $STAGING_URL
+  echo PRODUCTION_URL = $PRODUCTION_URL
+  echo STAGING_TOOL_DIR = $STAGING_TOOL_DIR
+  echo PRODUCTION_TOOL_DIR = $PRODUCTION_TOOL_DIR
 
-	# Jenkins build number
-	echo BUILD_NUMBER = $BUILD_NUMBER
-	echo INSTALL_ID = $INSTALL_ID
-	echo GIT_COMMIT = $GIT_COMMIT
-	echo GIT_PREVIOUS_COMMIT = $GIT_PREVIOUS_COMMIT
-	echo -------------------------------
+  # Jenkins build number
+  echo BUILD_NUMBER = $BUILD_NUMBER
+  echo INSTALL_ID = $INSTALL_ID
+  echo GIT_COMMIT = $GIT_COMMIT
+  echo GIT_PREVIOUS_COMMIT = $GIT_PREVIOUS_COMMIT
+  echo -------------------------------
 
-	# Virtual environment in build directory has ephemeris and bioblend installed.
-	# If this script is being run for the first time we will need to set up the
-	# virtual environment
-	if [ $LOCAL_ENV = 0 ]; then
-		VIRTUALENV="../.venv"
-		if [ ! -d $VIRTUALENV ]; then
-			echo "creating virtual environment";
-		        virtualenv $VIRTUALENV;
-			cd ..
-			pip install ephemeris
-			pip install bioblend
-			cd workspace
-		fi
-		. $VIRTUALENV/bin/activate
-	fi
+  # Virtual environment in build directory has ephemeris and bioblend installed.
+  # If this script is being run for the first time on the jenkins server we
+  # will need to set up the virtual environment
+  if [ $LOCAL_ENV = 0 ]; then
+    VIRTUALENV="../.venv"
+    if [ ! -d $VIRTUALENV ]; then
+      echo "creating virtual environment";
+            virtualenv $VIRTUALENV;
+      cd ..
+      pip install ephemeris
+      pip install bioblend
+      cd workspace
+    fi
+    . $VIRTUALENV/bin/activate
+  fi
 
-	# Ensure log file exists, create it if not
-	if [ ! -f $AUTOMATED_TOOL_INSTALLATION_LOG ]; then
-		echo -e $LOG_HEADER > $AUTOMATED_TOOL_INSTALLATION_LOG;
-		git add $AUTOMATED_TOOL_INSTALLATION_LOG; # this has to be a tracked file
-	fi
+  # Ensure log file exists, create it if not
+  if [ ! -f $AUTOMATED_TOOL_INSTALLATION_LOG ]; then
+    echo -e $LOG_HEADER > $AUTOMATED_TOOL_INSTALLATION_LOG;
+    git add $AUTOMATED_TOOL_INSTALLATION_LOG; # this has to be a tracked file
+  fi
 
-	# Arrange git diff into string "file1 file2 .. fileN"
-	FILE_ARGS=$REQUESTS_DIFF
-	if [ ! -f $REQUESTS_DIFF ]; then
-		FILE_ARGS=$(tr "\n" " " < $REQUESTS_DIFF)
-	fi
+  # check out master, get out of detached head
+  git checkout master
+  git pull
 
-	if [ $LOCAL_ENV = 0 ]; then
-		# enable pushing to github.  there is almost certainly a better way to do this
-		git remote set-url origin git@github.com:cat-bro/usegalaxy-au-tools.git
-		eval `ssh-agent`
-		ssh-add ~/.ssh/github_catbro_au_tools.rsa
-		# make sure we are not in detached head state by checking out master
-		git checkout master
-		git pull
-	fi
+  [ -d tmp ] || mkdir tmp;	# Important!  Make sure this exists
 
-	TOOL_FILE_PATH="requests/pending/$INSTALL_ID/"
-	mkdir -p $TOOL_FILE_PATH
+  # Concatenate logs from unsuccessfull installations/tests to ERROR_LOG
+  # to use in a subsequent pull request
+  ERROR_LOG="tmp/error_log.txt"
+  rm -f $ERROR_LOG ||:
+  touch $ERROR_LOG
 
-	# split requests into individual yaml files in requests/pending
-	# one file per unique revision so that installation can be run sequentially and
-	# failure of one installation will not affect the others
-	python scripts/organise_request_files.py -f $FILE_ARGS -o $TOOL_FILE_PATH
+  TOOL_FILE_PATH="requests/pending/$INSTALL_ID/"
+  mkdir -p $TOOL_FILE_PATH
 
-	NUM_TOOLS_TO_INSTALL=$(ls $TOOL_FILE_PATH | wc -l)
-	INSTALLED_TOOL_COUNTER=0
+  # split requests into individual yaml files in requests/pending
+  # one file per unique revision so that installation can be run sequentially and
+  # failure of one installation will not affect the others
 
-	for FILE_NAME in $(ls $TOOL_FILE_PATH)
-	do
-		TOOL_FILE=$TOOL_FILE_PATH$FILE_NAME
-		TOOL_REF=$(echo $FILE_NAME | cut -d'.' -f 1)
-		TOOL_NAME=$(echo $(grep -oE "name: (\w+)" "$TOOL_FILE") | awk '{print $2}');
+  # python scripts/organise_request_files.py -f $FILE_ARGS -o $TOOL_FILE_PATH
+  python scripts/organise_request_files.py -f $FILE_ARGS -o $TOOL_FILE_PATH
 
-		echo -e "\nInstalling $TOOL_NAME from file $TOOL_FILE"
-		cat $TOOL_FILE
+  # keep a count of successful installations
+  NUM_TOOLS_TO_INSTALL=$(ls $TOOL_FILE_PATH | wc -l)
+  INSTALLED_TOOL_COUNTER=0
 
-		{
-			echo -e "\nStep (1): Installing $TOOL_NAME on staging server";
-			install_tool "STAGING" $TOOL_FILE
-		} && {
-			echo -e "\nStep (2): Testing $TOOL_NAME on staging server";
-			test_tool "STAGING" $TOOL_FILE
-		} && {
-			echo -e "\nStep (3): Installing $TOOL_NAME on production server";
-			install_tool "PRODUCTION" $TOOL_FILE
-		} && {
-			echo -e "\nStep (4): Testing $TOOL_NAME on production server";
-			test_tool "PRODUCTION" $TOOL_FILE
-		}
-	done
+  for FILE_NAME in $(ls $TOOL_FILE_PATH)
+  do
+    TOOL_FILE=$TOOL_FILE_PATH$FILE_NAME;
+    TOOL_REF=$(echo $FILE_NAME | cut -d'.' -f 1);
+    TOOL_NAME=$(echo $TOOL_REF | cut -d '@' -f 1);
+    REQUESTED_REVISION=$(echo $TOOL_REF | cut -d '@' -f 2);
+    OWNER=$(grep -oE "owner: .*$" "$TOOL_FILE" | cut -d ':' -f 2);
+    TOOL_SHED_URL=$(grep -oE "tool_shed_url: .*$" "$TOOL_FILE" | cut -d ':' -f 2);
+    SECTION_LABEL=$(grep -oE "tool_panel_section_label: .*$" "$TOOL_FILE" | cut -d ':' -f 2);
 
-	echo "$INSTALLED_TOOL_COUNTER out of $NUM_TOOLS_TO_INSTALL tools installed."
-	if [ ! "$LOG_ENTRY" ]; then
-		echo "WARNING: No log entry stored";
-	else
-		echo "Writing entry to $AUTOMATED_TOOL_INSTALLATION_LOG"
-		echo "=================================================="
-		echo -e $LOG_HEADER
-		echo -e $LOG_ENTRY
-		echo "=================================================="
-		echo -e $LOG_ENTRY >> $AUTOMATED_TOOL_INSTALLATION_LOG;
+    unset STAGING_TESTS_PASSED
+    unset PRODUCTION_TESTS_PASSED
 
-		update_tool_list "STAGING"
-		update_tool_list "PRODUCTION"
+    echo -e "\nInstalling $TOOL_NAME from file $TOOL_FILE"
+    cat $TOOL_FILE
 
-		# Push changes to github
-		# Add any new tool list files that have been created.
-		for YML_FILE in $(ls $STAGING_TOOL_DIR)
-	  do
-	    git add $STAGING_TOOL_DIR/$YML_FILE
-	  done
-		for YML_FILE in $(ls $PRODUCTION_TOOL_DIR)
-	  do
-	    git add $PRODUCTION_TOOL_DIR/$YML_FILE
-	  done
+    {
+      echo -e "\nStep (1): Installing $TOOL_NAME on staging server";
+      install_tool "STAGING" $TOOL_FILE
+    } && {
+      echo -e "\nStep (2): Testing $TOOL_NAME on staging server";
+      test_tool "STAGING" $TOOL_FILE
+    } && {
+      echo -e "\nStep (3): Installing $TOOL_NAME on production server";
+      install_tool "PRODUCTION" $TOOL_FILE
+    } && {
+      echo -e "\nStep (4): Testing $TOOL_NAME on production server";
+      test_tool "PRODUCTION" $TOOL_FILE
+    }
+  done
 
-		for FILE_NAME in $(ls $TOOL_FILE_PATH)
-		do
-			git add $TOOL_FILE_PATH$FILE_NAME
-		done
-		for FILE_NAME in $REQUESTS_DIFF
-		do
-			git rm $FILE_NAME
-		done
+  echo -e "\n$INSTALLED_TOOL_COUNTER out of $NUM_TOOLS_TO_INSTALL tools installed."
+  if [ ! "$LOG_ENTRY" ]; then
+    echo -e "\nWARNING: No log entry stored";
+  else
+    echo -e "\nWriting entry to $AUTOMATED_TOOL_INSTALLATION_LOG"
+    echo "=================================================="
+    echo -e $LOG_HEADER
+    echo -e $LOG_ENTRY
+    echo "=================================================="
+    echo -e $LOG_ENTRY >> $AUTOMATED_TOOL_INSTALLATION_LOG;
+  fi
 
-		# For the benefit of development log ALL git changes, per file
-		for filepath in $(git diff --name-only | cat)
-		do
-			git diff $filepath | cat
-			echo
-		done
-		COMMIT_MESSAGE="Jenkins build $BUILD_NUMBER."
+  COMMIT_FILES=($AUTOMATED_TOOL_INSTALLATION_LOG)
 
-		echo -e "\nPushing Changes to github"
-		git commit -a -m "$COMMIT_MESSAGE"
-		git pull;
-		git push
-		echo -e "\nDone"
-	fi
+  update_tool_list "STAGING"
+  update_tool_list "PRODUCTION"
+
+  # Push changes to github
+
+  # Add any new tool list files that have been created.
+  for YML_FILE in $(ls $STAGING_TOOL_DIR)
+  do
+    git add $STAGING_TOOL_DIR/$YML_FILE
+    COMMIT_FILES+=($STAGING_TOOL_DIR/$YML_FILE)
+  done
+  for YML_FILE in $(ls $PRODUCTION_TOOL_DIR)
+  do
+    git add $PRODUCTION_TOOL_DIR/$YML_FILE
+    COMMIT_FILES+=($PRODUCTION_TOOL_DIR/$YML_FILE)
+  done
+
+  # Remove files from original pull request
+
+  # for FILE in $REQUESTS_DIFF
+  for FILE in $FILE_ARGS
+  do
+    git rm $FILE
+    COMMIT_FILES+=($FILE)
+  done
+
+  # log all git changes
+  git diff | cat;
+  git diff --staged | cat;
+
+  echo -e "\nPushing Changes to github"
+  COMMIT_MESSAGE="Jenkins build $BUILD_NUMBER."
+  git commit ${COMMIT_FILES[@]} -m "$COMMIT_MESSAGE"
+  git pull
+  git push
+
+  if [[ $(ls $TOOL_FILE_PATH ) ]]; then
+    # Open up a new PR with any tool revisions that have failed installation
+    COMMIT_PR_FILES=()
+    echo 'Opening new pull request for remaining files:';
+    echo $(ls $TOOL_FILE_PATH );
+    BRANCH_NAME="jenkins/tools_$BUILD_NUMBER/$INSTALL_ID"
+    git checkout -b $BRANCH_NAME
+    for FILE_NAME in $(ls $TOOL_FILE_PATH)
+    do
+      mv $TOOL_FILE_PATH$FILE_NAME "requests/$FILE_NAME"
+      git add "requests/$FILE_NAME"
+      COMMIT_PR_FILES+=("requests/$FILE_NAME")
+    done
+    git commit ${COMMIT_PR_FILES[@]} -m "Jenkins build $BUILD_NUMBER errors"
+    git push --set-upstream origin $BRANCH_NAME
+    # Use 'hub' command to open pull request
+    # hub takes a text file where a blank line separates the PR title from
+    # the PR description.
+    PR_FILE='tmp/hub_pull_request_file'
+    echo -e "Jenkins build $BUILD_NUMBER errors\n\n" > $PR_FILE
+    cat $ERROR_LOG >> $PR_FILE
+    hub pull-request -F $PR_FILE
+    rm $PR_FILE
+    git checkout master
+  fi
+  rm -r $TOOL_FILE_PATH
+
+  echo -e "\nDone"
 }
 
 test_tool() {
-	# Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path
-	TOOL_FILE="$2"
-	SERVER="$1"
-	if [ $SERVER = "STAGING" ]; then
-		API_KEY=$STAGING_API_KEY
-		URL=$STAGING_URL
-		TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_staging_test.json
-		STEP="Staging Testing"
-	elif [ $SERVER = "PRODUCTION" ]; then
-		API_KEY=$PRODUCTION_API_KEY
-		URL=$PRODUCTION_URL
-		TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_production_test.json
-		STEP="Production Testing"
-	else
-		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
-		return 1
-	fi
+  # Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path
+  TOOL_FILE="$2"
+  SERVER="$1"
+  if [ $SERVER = "STAGING" ]; then
+    API_KEY=$STAGING_API_KEY
+    URL=$STAGING_URL
+    TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_staging_test.json
+    STEP="Staging Testing"
+  elif [ $SERVER = "PRODUCTION" ]; then
+    API_KEY=$PRODUCTION_API_KEY
+    URL=$PRODUCTION_URL
+    TEST_JSON="$LOG_DIR"/"$INSTALL_ID"_production_test.json
+    STEP="Production Testing"
+  else
+    echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+    return 1
+  fi
 
-	TEST_LOG='tmp/test_log.txt'
-	rm -f $TEST_LOG ||:;  # delete if it does not exist
+  TEST_LOG='tmp/test_log.txt'
+  rm -f $TEST_LOG ||:;  # delete if it does not exist
 
-	command="shed-tools test -g $URL -a $API_KEY -t $TOOL_FILE --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
-	echo "${command/$API_KEY/<API_KEY>}"
-	$command || return 1
-	echo
-	if [ $BASH_V = 4 ]; then
-		# normal regex
-		[[ $(cat $TEST_LOG) =~ "Passed tool tests \(([0-9])\)" ]];
-		TESTS_PASSED="${BASH_REMATCH[1]}"
-		[[ $(cat $TEST_LOG) =~ "Failed tool tests \(([0-9])\)" ]];
-		TESTS_FAILED="${BASH_REMATCH[1]}"
-	else
-		# resort to python helper
-		TESTS_PASSED="$(python scripts/first_match_regex.py -p 'Passed tool tests \((\d+)\)' $TEST_LOG)"
-		TESTS_FAILED="$(python scripts/first_match_regex.py -p 'Failed tool tests \((\d+)\)' $TEST_LOG)"
-	fi
-	if [ $TESTS_FAILED = 0 ]; then
-		if [ $TESTS_PASSED = 0 ]; then
-			echo "WARNING: There are no tests for $TOOL_NAME at revision $INSTALLED_REVISION.  Proceeding as none have failed.";
-		else
-			echo "All tests have passed for $TOOL_NAME at revision $INSTALLED_REVISION on $URL.";
-		fi
-		if [ "$SERVER" = "PRODUCTION" ]; then
-			unset STEP
-			log_row "Success"
-			exit_installation 0 ""
-			return 0
-		fi
-		echo -e "\nSuccessfully installed $TOOL_NAME on $URL\n";
-	else
-		echo "Failed to install: Winding back installation as some tests have failed.";
-		echo "Uninstalling on $URL";
-		python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
-		if [ $SERVER = "PRODUCTION" ]; then
-			# also uninstall on staging
-			echo "Uninstalling on $STAGING_URL";
-			python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
-		fi
-		log_row "Tests failed"
-		exit_installation 1 ""
-		return 1
-	fi
+  command="shed-tools test -g $URL -a $API_KEY -t $TOOL_FILE --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
+  echo "${command/$API_KEY/<API_KEY>}"
+  $command || return 1
+  echo
+  if [ $BASH_V = 4 ]; then
+    # normal regex
+    PATTERN="Passed tool tests \(([0-9]+)\)"
+    [[ $(cat $TEST_LOG) =~ $PATTERN ]];
+    TESTS_PASSED="${BASH_REMATCH[1]}"
+    PATTERN="Failed tool tests \(([0-9]+)\)"
+    [[ $(cat $TEST_LOG) =~ $PATTERN ]];
+    TESTS_FAILED="${BASH_REMATCH[1]}"
+  else
+    # resort to python helper
+    TESTS_PASSED="$(python scripts/first_match_regex.py -p 'Passed tool tests \((\d+)\)' $TEST_LOG)"
+    TESTS_FAILED="$(python scripts/first_match_regex.py -p 'Failed tool tests \((\d+)\)' $TEST_LOG)"
+  fi
+  [ $SERVER = "STAGING" ] && STAGING_TESTS_PASSED="$TESTS_PASSED/$(($TESTS_PASSED+$TESTS_FAILED))";
+  [ $SERVER = "PRODUCTION" ] && PRODUCTION_TESTS_PASSED="$TESTS_PASSED/$(($TESTS_PASSED+$TESTS_FAILED))";
+  if [ $TESTS_FAILED = 0 ]; then
+    if [ $TESTS_PASSED = 0 ]; then
+      echo "WARNING: There are no tests for $TOOL_NAME at revision $INSTALLED_REVISION.  Proceeding as none have failed.";
+    else
+      echo "All tests have passed for $TOOL_NAME at revision $INSTALLED_REVISION on $URL.";
+    fi
+    if [ "$SERVER" = "PRODUCTION" ]; then
+      echo "Successfully installed $TOOL_NAME on $URL\n";
+      unset STEP
+      log_row "Installed"
+      exit_installation 0 ""
+      rm $TOOL_FILE; # remove installation file in requests/pending
+      return 0
+    fi
+  else
+    echo "Failed to install: Winding back installation as some tests have failed.";
+    echo "Uninstalling on $URL";
+    python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
+    if [ $SERVER = "PRODUCTION" ]; then
+      # also uninstall on staging
+      echo "Uninstalling on $STAGING_URL";
+      python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
+    fi
+    log_row "Tests failed"
+    echo -e "Failed to install $TOOL_NAME. Tests failed on  $URL.\n" >> $ERROR_LOG
+    cat $TEST_LOG >> $ERROR_LOG; echo -e "\n\n" >> $ERROR_LOG;
+    exit_installation 1 ""
+    return 1
+  fi
 }
 
 install_tool() {
-	# Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path, $3 = repeat (default 1)
-	if [ "$3" ]; then
-		REPEAT="$3";
-	else
-		REPEAT=1
-	fi
+  # Positional arguments: $1 = STAGING|PRODUCTION, $2 = tool file path, $3 = repeat (default 1)
+  if [ "$3" ]; then
+    REPEAT="$3";
+  else
+    REPEAT=1
+  fi
 
-	TOOL_FILE="$2"
-	SERVER="$1"
-	if [ $SERVER = "STAGING" ]; then
-		API_KEY=$STAGING_API_KEY
-		URL=$STAGING_URL
-		STEP="Staging Installation"
-	elif [ $SERVER = "PRODUCTION" ]; then
-		API_KEY=$PRODUCTION_API_KEY
-		URL=$PRODUCTION_URL
-		STEP="Production Installation"
-	else
-		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
-		return 1
-	fi
+  TOOL_FILE="$2"
+  SERVER="$1"
+  if [ $SERVER = "STAGING" ]; then
+    API_KEY=$STAGING_API_KEY
+    URL=$STAGING_URL
+    STEP="Staging Installation"
+  elif [ $SERVER = "PRODUCTION" ]; then
+    API_KEY=$PRODUCTION_API_KEY
+    URL=$PRODUCTION_URL
+    STEP="Production Installation"
+  else
+    echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+    return 1
+  fi
 
-	INSTALL_LOG='tmp/install_log.txt'
-	rm -f $INSTALL_LOG ||:;  # delete if it does not exist
+  INSTALL_LOG='tmp/install_log.txt'
+  rm -f $INSTALL_LOG ||:;  # delete if it does not exist
 
-	# Ephemeris install script
-	command="shed-tools install -g $URL -a $API_KEY -t $TOOL_FILE -v --log_file $INSTALL_LOG"
-	echo "${command/$API_KEY/<API_KEY>}"; # substitute API_KEY for printing
-	$command || return 1
+  # Ephemeris install script
+  command="shed-tools install -g $URL -a $API_KEY -t $TOOL_FILE -v --log_file $INSTALL_LOG"
+  echo "${command/$API_KEY/<API_KEY>}"; # substitute API_KEY for printing
+  $command || return 1
 
-	# Capture the status (Installed/Skipped/Errored), name and revision hash from ephemeris output
-	if [ $BASH_V = 4 ]; then
-		PATTERN="(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]"
-		[[ $(cat $INSTALL_LOG) =~ $PATTERN ]];
-		INSTALLATION_STATUS="${BASH_REMATCH[1]}";
-		INSTALLED_NAME="${BASH_REMATCH[2]}";
-		INSTALLED_REVISION="${BASH_REMATCH[3]}";
-		echo $INSTALLATION_STATUS
-		echo $INSTALLED_NAME
-		echo $INSTALLED_REVISION
-	else # the regex above does not work on my local machine (Mac), hence this python workaround
-		SHED_TOOLS_VALUES=($(python scripts/first_match_regex.py -p "(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]" $INSTALL_LOG));
-	fi
-	if [ $SHED_TOOLS_VALUES ]; then
-		INSTALLATION_STATUS="${SHED_TOOLS_VALUES[0]}";
-		INSTALLED_NAME="${SHED_TOOLS_VALUES[1]}";
-		INSTALLED_REVISION="${SHED_TOOLS_VALUES[2]}";
-	fi
-	# If all three values are not null, proceed only if status is Installed,
-	# write log entry and leave otherwise
-	if [ "$INSTALLATION_STATUS" ] && [ "$INSTALLED_NAME" ] && [ "$INSTALLED_REVISION" ]; then
-		if [ ! $INSTALLATION_STATUS = 'Installed' ]; then
-			if [ $INSTALLATION_STATUS = "Errored" ]; then
-				# The tool may or may not be installed according to the API, so it needs to be
-				# uninstalled with bioblend
-				echo "Installation error.  Uninstalling $TOOL_NAME on $URL";
-				python scripts/uninstall_tools.py -g $URL -a $API_KEY -n "$INSTALLED_NAME@$INSTALLED_REVISION";
-				if [ $SERVER = "PRODUCTION" ]; then
-					# also uninstall on staging
-					echo "Uninstalling $TOOL_NAME on $STAGING_URL";
-					python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
-				fi
-				echo "Halting unsuccessful installation";
-			elif [ $INSTALLATION_STATUS = "Skipped" ]; then
-				# Note that linting process should prevent this scenario
-				echo "Package appears to be already installed on $URL";
-			fi
-			log_row $INSTALLATION_STATUS
-			exit_installation 1 ""
-			# TODO: Should files be moved elsewhere?
-			return 1;
-		else
-			if [ ! "$TOOL_NAME" = "$INSTALLED_NAME" ]; then
-				# Sanity check.  If these are not the same name, uninstall and abandon process with 'Script error'
-				python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
-				log_row "Script Error"
-				exit_installation 1 "Unexpected value for name of installed tool."
-				return 1
-			fi
-		fi
-		else
-			# TODO what if this is production server?  wind back staging installation?
-			log_row "Script error"
-			exit_installation 1 "Could not verify installation from shed-tools output."
-			return 1
-	fi
+  # Capture the status (Installed/Skipped/Errored), name and revision hash from ephemeris output
+  if [ $BASH_V = 4 ]; then
+    PATTERN="(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]"
+    [[ $(cat $INSTALL_LOG) =~ $PATTERN ]];
+    INSTALLATION_STATUS="${BASH_REMATCH[1]}";
+    INSTALLED_NAME="${BASH_REMATCH[2]}";
+    INSTALLED_REVISION="${BASH_REMATCH[3]}";
+  else # the regex above does not work on my local machine (Mac), hence this python workaround
+    SHED_TOOLS_VALUES=($(python scripts/first_match_regex.py -p "(\w+) repositories \(1\): \[\('([^']+)',\s*u?'(\w+)'\)\]" $INSTALL_LOG));
+  fi
+  if [ $SHED_TOOLS_VALUES ]; then
+    INSTALLATION_STATUS="${SHED_TOOLS_VALUES[0]}";
+    INSTALLED_NAME="${SHED_TOOLS_VALUES[1]}";
+    INSTALLED_REVISION="${SHED_TOOLS_VALUES[2]}";
+  fi
+  # If all three values are not null, proceed only if status is Installed,
+  # write log entry and leave otherwise
+  if [ "$INSTALLATION_STATUS" ] && [ "$INSTALLED_NAME" ] && [ "$INSTALLED_REVISION" ]; then
+    if [ ! "$TOOL_NAME" = "$INSTALLED_NAME" ]; then
+      # Sanity check.  If these are not the same name, uninstall and abandon process with 'Script error'
+      python scripts/uninstall_tools.py -g $URL -a $API_KEY -n $INSTALLED_NAME;
+      log_row "Script Error"
+      exit_installation 1 "Unexpected value for name of installed tool."
+      return 1
+    fi
+    if [ ! $INSTALLATION_STATUS = "Installed" ]; then
+      if [ $INSTALLATION_STATUS = "Errored" ]; then
+        # The tool may or may not be installed according to the API, so it needs to be
+        # uninstalled with bioblend
+        echo "Installation error.  Uninstalling $TOOL_NAME on $URL";
+        python scripts/uninstall_tools.py -g $URL -a $API_KEY -n "$INSTALLED_NAME@$INSTALLED_REVISION";
+        if [ $SERVER = "PRODUCTION" ]; then
+          # also uninstall on staging
+          echo "Uninstalling $TOOL_NAME on $STAGING_URL";
+          python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n $INSTALLED_NAME;
+        fi
+      elif [ $INSTALLATION_STATUS = "Skipped" ]; then
+        # Note that linting process should prevent this scenario
+        echo "Package appears to be already installed on $URL";
+      fi
+      log_row $INSTALLATION_STATUS
+      echo -e "Failed to install $TOOL_NAME on $URL (status $INSTALLATION_STATUS)\n" >> $ERROR_LOG
+      cat $INSTALL_LOG >> $ERROR_LOG; echo -e "\n\n" >> $ERROR_LOG;
+      exit_installation 1 ""
+      return 1;
+    else
+      echo "$TOOL_NAME has been installed on $URL";
+    fi
+    else
+      # TODO what if this is production server?  wind back staging installation?
+      log_row "Script error"
+      exit_installation 1 "Could not verify installation from shed-tools output."
+      return 1
+  fi
 }
 
 log_row() {
-	# 'Jenkins Build Number\tInstall ID\tLog Path\tStatus\tFailing Step\tName'
-	# TODO: What are relevant log values?  Owner.  Revision.  Section.  Toolshed URL. Start time.  Finish time.  Elapsed time.
-	STATUS="$1"
-	if [ "$LOG_ENTRY" ]; then
-		LOG_ENTRY="$LOG_ENTRY\n";	# If log entry has content, add new line before new content
-	fi
-	LOG_ROW="$BUILD_NUMBER\t$INSTALL_ID\t$LOG_FILE\t$STATUS\t$STEP\t$TOOL_NAME"
+  # "Jenkins Build Number\tInstall ID\tDate (UTC)\tStatus\tFailing Step\tStaging tests passed\tProduction tests passed\tName\tOwner\tRequested Revision\tInstalled Revision\tSection Label\tTool Shed URL\tLog Path"
+  STATUS="$1"
+  if [ "$LOG_ENTRY" ]; then
+    LOG_ENTRY="$LOG_ENTRY\n";	# If log entry has content, add new line before new content
+  fi
+  LOG_ROW="$BUILD_NUMBER\t$INSTALL_ID\t$(date)\t$STATUS\t$STEP\t$STAGING_TESTS_PASSED\t$PRODUCTION_TESTS_PASSED\t$TOOL_NAME\t$OWNER\t$REQUESTED_REVISION\t$INSTALLED_REVISION\t$SECTION_LABEL\t$TOOL_SHED_URL\t$LOG_FILE"
   LOG_ENTRY="$LOG_ENTRY$LOG_ROW"
-	# echo -e $LOG_ROW; # Need to print this values?  Store them in multiD array? What if script stops in the middle?
+  # echo -e $LOG_ROW; # Need to print this values?  Store them in multiD array? What if script stops in the middle?
 }
 
+
 exit_installation() {
-	unset OUTCOME
-	FAILED="$1"; # 0 for success, 1 for failure
-	MESSAGE="$2";
-	if [ "$FAILED" = "1" ]; then
-		OUTCOME="Failed to install"
-	elif [ "$FAILED" = "0" ]; then
-		OUTCOME="Successfully installed"
-		INSTALLED_TOOL_COUNTER=$((INSTALLED_TOOL_COUNTER+1))
-	fi
-	echo -e "\n$OUTCOME $TOOL_NAME." $MESSAGE
+  unset OUTCOME
+  FAILED="$1"; # 0 for success, 1 for failure
+  MESSAGE="$2";
+  if [ "$FAILED" = "1" ]; then
+    OUTCOME="Failed to install"
+  elif [ "$FAILED" = "0" ]; then
+    OUTCOME="Successfully installed"
+    INSTALLED_TOOL_COUNTER=$((INSTALLED_TOOL_COUNTER+1))
+  fi
+  echo -e "\n$OUTCOME $TOOL_NAME." $MESSAGE
 }
 
 update_tool_list() {
-	SERVER="$1"
-	if [ $SERVER = "STAGING" ]; then
-		API_KEY=$STAGING_API_KEY
-		URL=$STAGING_URL
-		TOOL_DIR=$STAGING_TOOL_DIR
-	elif [ $SERVER = "PRODUCTION" ]; then
-		API_KEY=$PRODUCTION_API_KEY
-		URL=$PRODUCTION_URL
-		TOOL_DIR=$PRODUCTION_TOOL_DIR
-	else
-		echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
-		return 1
-	fi
+  SERVER="$1"
+  if [ $SERVER = "STAGING" ]; then
+    API_KEY=$STAGING_API_KEY
+    URL=$STAGING_URL
+    TOOL_DIR=$STAGING_TOOL_DIR
+  elif [ $SERVER = "PRODUCTION" ]; then
+    API_KEY=$PRODUCTION_API_KEY
+    URL=$PRODUCTION_URL
+    TOOL_DIR=$PRODUCTION_TOOL_DIR
+  else
+    echo "First positional argument must be STAGING or PRODUCTION.  Exiting"
+    return 1
+  fi
 
-	TMP_TOOL_FILE=tmp/tool_list.yml
-	rm -f $TMP_TOOL_FILE ||:; # remove file if it exists
-	get-tool-list -g $URL -a $API_KEY -o $TMP_TOOL_FILE --get_data_managers
-	python scripts/split_tool_yml.py -i $TMP_TOOL_FILE -o $TOOL_DIR; # Simon's script
+  TMP_TOOL_FILE=tmp/tool_list.yml
+  rm -f $TMP_TOOL_FILE ||:; # remove temp file if it exists
+  [ -d $TOOL_DIR ] || mkdir $TOOL_DIR  # make directory if it does not exist
+  get-tool-list -g $URL -a $API_KEY -o $TMP_TOOL_FILE --get_data_managers
+  python scripts/split_tool_yml.py -i $TMP_TOOL_FILE -o $TOOL_DIR; # Simon's script
+  rm $TMP_TOOL_FILE
 }
 
 install_tools

--- a/requests/template/template.yml
+++ b/requests/template/template.yml
@@ -1,0 +1,8 @@
+tools:
+  - name:
+    owner:
+    tool_panel_section_label:
+    tool_shed_url: # optional: omit this line to use default 'toolshed.g2.bx.psu.edu'
+    revisions: # optional: omit this section to use default latest available revision
+      - revision_hash_1
+      - revision_hash_2

--- a/scripts/first_match_regex.py
+++ b/scripts/first_match_regex.py
@@ -1,0 +1,26 @@
+import re
+import argparse
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description='Mimic bash pattern matching')
+    parser.add_argument('-p', '--pattern', help='Pattern to match')
+    parser.add_argument('file_path', help='File in which to find first match')
+    args = parser.parse_args()
+
+    first_match_regex(args.file_path, args.pattern)
+
+def first_match_regex(path, pattern):
+    # Hack to produce the same values that would be stored in BASH_REMATCH[1:] if
+    # it were working on mac.
+    compiled_pattern = re.compile(
+        pattern,
+        re.MULTILINE,
+    )
+    with open(path) as logfile:
+        matches = compiled_pattern.findall(logfile.read())
+    if len(matches) > 0:
+        match = matches[0]
+        sys.stdout.write('%s' % ' '.join(match))  # value returned to shell through stdout
+
+if __name__ == "__main__": main()

--- a/scripts/organise_request_files.py
+++ b/scripts/organise_request_files.py
@@ -1,0 +1,45 @@
+import yaml
+import argparse
+
+
+def main():
+    VERSION = 'development'
+
+    parser = argparse.ArgumentParser(description='Rewrite arbitrarily many tool yml files as one file per tool revision')
+    parser.add_argument('-o', '--output_path', help='Output file path')
+    parser.add_argument('-f', '--files', help='Tool input files', nargs='+')
+
+    args = parser.parse_args()
+
+    files = args.files
+    path = args.output_path
+
+    tools_by_entry = []
+    for file in files:
+        with open(file) as input:
+            content = yaml.safe_load(input.read())['tools']
+            if isinstance(content, list):
+                tools_by_entry += content
+            else:
+                tools_by_entry.append(content)
+
+    for tool in tools_by_entry:
+        if 'revisions' in tool.keys() and len(tool['revisions']) > 1:
+            tool_revisions = []
+            for rev in tool['revisions']:
+                new_tool = tool
+                new_tool['revisions'] = [rev]
+                write_output_file(path=path, tool=new_tool)
+        else:
+            write_output_file(path=path, tool=tool)
+
+def write_output_file(path, tool):
+    if not path[-1] == '/':
+        path = path + '/'
+    [revision] = tool['revisions'] if 'revisions' in tool.keys() else ['latest']
+    file_path = '%s%s@%s.yml' % (path, tool['name'], revision)
+    print('writing file ' + file_path)
+    with open(file_path, 'w') as outfile:
+        outfile.write(yaml.dump({'tools': [tool]}))
+
+if __name__ == "__main__": main()

--- a/scripts/split_tool_yml.py
+++ b/scripts/split_tool_yml.py
@@ -4,8 +4,8 @@ import yaml
 from collections import defaultdict
 import re
 import os
-import sys
 import argparse
+
 
 def slugify(value):
     """
@@ -15,6 +15,7 @@ def slugify(value):
     value = re.sub('[^\w\s-]', '', value).strip().lower()
     value = re.sub('[-\s]+', '_', value)
     return value
+
 
 def main():
 
@@ -35,7 +36,7 @@ def main():
     filename = args.infile
 
     a = yaml.safe_load(open(filename, 'r'), )
-    outdir = re.sub('\.yml','',filename)
+    outdir = re.sub('\.yml', '', filename)
     if args.outdir:
         outdir = args.outdir
 
@@ -53,7 +54,7 @@ def main():
     for cat in categories:
         fname = str(cat)
         good_fname = outdir + "/" + slugify(fname) + ".yml"
-        tool_yaml = {'tools': categories[cat]}
+        tool_yaml = {'tools': sorted(categories[cat], key=lambda x: x['name'] + x['owner'])}
         if args.verbose:
             print("Working on: %s" % good_fname)
         with open(good_fname, 'w') as outfile:

--- a/scripts/uninstall_tools.py
+++ b/scripts/uninstall_tools.py
@@ -47,7 +47,7 @@ def uninstall_tools(galaxy_server, api_key, names, force):
     galaxy_instance = GalaxyInstance(url=galaxy_server, key=api_key)
     toolshed_client = ToolShedClient(galaxy_instance)
 
-    temp_tool_list_file = 'tmp/tool_list.yml'
+    temp_tool_list_file = 'tmp/installed_tool_list.yml'
     # TODO: Switch to using bioblend to obtain this list
     # ephemeris uses bioblend but without using ephemeris we cut out the need to for a temp file
     os.system('get-tool-list -g %s -a %s -o %s --get_all_tools' % (galaxy_server, api_key, temp_tool_list_file))

--- a/scripts/uninstall_tools.py
+++ b/scripts/uninstall_tools.py
@@ -25,10 +25,7 @@ def main():
     parser.add_argument(
         '-f',
         '--force',
-        help=(
-            'If there are several toolshed entries for one name or name/revision entry uninstall all of them'
-            ' (the default behaviour is to not uninstall and print a warning)'
-        ),
+        help='If there are several toolshed entries for one name or name/revision entry uninstall all of them',
         action='store_true',
     )
 

--- a/scripts/uninstall_tools.py
+++ b/scripts/uninstall_tools.py
@@ -1,0 +1,94 @@
+from bioblend.galaxy import GalaxyInstance
+from bioblend.galaxy.toolshed import ToolShedClient
+import argparse
+import yaml
+import os
+import sys
+
+"""
+Uninstall tools from a galaxy instance via the API using the bioblend package.
+This can be used to uninstall any galaxy toolshed tool.  The main use case is
+when a tool has been installed incorrectly or when an error has occurred during
+installation causing the tool to be partially installed.
+"""
+
+def main():
+    parser = argparse.ArgumentParser(description='Uninstall tool from a galaxy instance')
+    parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL')
+    parser.add_argument('-a', '--api_key', help='API key for galaxy server')
+    parser.add_argument(
+        '-n',
+        '--names',
+        help='Names of tools to uninstall.  These can include revision hashes e.g. --names name1@revision1 name1@revision2 name2 ',
+        nargs='+',
+    )
+    parser.add_argument(
+        '-f',
+        '--force',
+        help=(
+            'If there are several toolshed entries for one name or name/revision entry uninstall all of them'
+            ' (the default behaviour is to not uninstall and print a warning)'
+        ),
+        action='store_true',
+    )
+
+    args = parser.parse_args()
+    galaxy_url = args.galaxy_url
+    api_key = args.api_key
+    names = args.names
+    force = args.force
+
+    if not names:
+        raise Exception('Arguments --names (-n) must be provided.')
+
+    uninstall_tools(galaxy_url, api_key, names, force)
+
+def uninstall_tools(galaxy_server, api_key, names, force):
+    galaxy_instance = GalaxyInstance(url=galaxy_server, key=api_key)
+    toolshed_client = ToolShedClient(galaxy_instance)
+
+    temp_tool_list_file = 'tmp/tool_list.yml'
+    # TODO: Switch to using bioblend to obtain this list
+    # ephemeris uses bioblend but without using ephemeris we cut out the need to for a temp file
+    os.system('get-tool-list -g %s -a %s -o %s --get_all_tools' % (galaxy_server, api_key, temp_tool_list_file))
+
+    tools_to_uninstall = []
+    with open(temp_tool_list_file) as tool_file:
+        installed_tools = yaml.safe_load(tool_file.read())['tools']
+    if not installed_tools:
+        raise Exception('No tools to uninstall')
+    os.system('rm %s' % temp_tool_list_file)
+
+    for name in names:
+        revision = None
+        if '@' in name:
+            (name, revision) = name.split('@')
+        matching_tools = [t for t in installed_tools if t['name'] == name and (not revision or revision in t['revisions'])]
+        if len(matching_tools) == 0:
+            id_string = 'name %s revision %s' % (name, revision) if revision else 'name %s' % name
+            print('*** Warning: No tool with %s\n' % id_string)
+        elif len(matching_tools) > 1 and not force:
+            print(
+                '*** Warning: More than one toolshed tool found for %s.  ' % name
+                + 'Not uninstalling any of these tools.  Run script with --force (-f) flag to uninstall anyway'
+            )
+        else:  # Either there is only one matching tool for the name and revision, or there are many and force=True
+            for tool in matching_tools:
+                tool_copy = tool.copy()
+                if revision:
+                    tool_copy['revisions'] = [revision]
+                tools_to_uninstall.append(tool_copy)
+
+    for tool in tools_to_uninstall:
+        try:
+            name = tool['name']
+            owner = tool['owner']
+            tool_shed_url = tool['tool_shed_url']
+            revision = tool['revisions'][0]
+            print('Uninstalling %s at revision %s' % (name, revision))
+            return_value = toolshed_client.uninstall_repository_revision(name=name, owner=owner, changeset_revision=revision, tool_shed_url=tool_shed_url)
+            print(return_value)
+        except KeyError as e:
+            print(e)
+
+if __name__ == "__main__": main()


### PR DESCRIPTION
Script for automatic tool installation with Jenkins when a commit is pushed in usegalaxy-au-tools.  This has been developed on a fork of the repo with a signal sent to a Jenkins server for each commit.

Test galaxy instances galaxy-cat.genome.edu.au and cat-dev.genome.edu.au have been used to stand in for staging and production galaxy servers.  These can be updated to production and staging urls in .env.

The script jenkins/main.sh processes changed files from the latest commit and will start the installation process if there are any new installation files (files in the requests directory).  The script jenkins/webhook_install_tools.sh goes through installation and testing on staging and production servers in order, processing one tool/revision at at a time.  It will halt on installation errors or failing tests.  Any tools that are not installed are added to another pull request with information on installation/test failure.

There are still some to-do items:
- Simon has mentioned having a flag to ignore test errors.
- The github/jenkins process needs Slack integration.
- The README needs to be updated with instructions on requesting tools through the github repo.
- The linting process is missing a step for checking whether the section label is within a list of allowed labels
- This needs to be anchored to an ephemeris version since a lot depends on parsing the shed-tools output.
- There is a python script in here (scripts/first_match_regex.py) which is a bit embarrassing but helped for running the script locally with bash 3, as opposed to bash 4 (on ubuntu) which has much better regex support.  I'll need to clean this up.