### PR TITLE
Differetiate between "install" and "update" jenkins builds

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -157,13 +157,13 @@ install_tools() {
       git add $PR_FILE
       COMMIT_PR_FILES+=("$PR_FILE")
     done
-    git commit "${COMMIT_PR_FILES[@]}" -m "Jenkins build $BUILD_NUMBER errors"
+    git commit "${COMMIT_PR_FILES[@]}" -m "Jenkins $MODE build $BUILD_NUMBER errors"
     git push --set-upstream origin $BRANCH_NAME
     # Use 'hub' command to open pull request
     # hub takes a text file where a blank line separates the PR title from
     # the PR description.
     PR_FILE="$TMP/hub_pull_request_file"
-    echo -e "Jenkins build $BUILD_NUMBER errors\n\n" > $PR_FILE
+    echo -e "Jenkins $MODE build $BUILD_NUMBER errors\n\n" > $PR_FILE
     cat $ERROR_LOG >> $PR_FILE
     hub pull-request -F $PR_FILE
     rm $PR_FILE
@@ -308,7 +308,7 @@ test_tool() {
   SERVER="$1"
   set_url $SERVER
   STEP="$(title $SERVER) Testing"; # Production Testing or Staging Testing
-  TEST_JSON="$LOG_DIR/$BUILD_NUMBER"_"$(lower $SERVER)"_test.json
+  TEST_JSON="$LOG_DIR/${MODE}_build_${BUILD_NUMBER}_$(lower $SERVER)_test.json"
 
   # Special case: If package is already installed on staging we skip tests and install on production
   if [ $SERVER = "STAGING" ] && [ $INSTALLATION_STATUS = "Skipped" ]; then

--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -43,7 +43,7 @@ fi
 [ -d $LOG_DIR ] || mkdir $LOG_DIR;
 
 export BUILD_NUMBER=$BUILD_NUMBER
-export LOG_FILE="$LOG_DIR/webhook_tool_installation_$BUILD_NUMBER"
+export LOG_FILE="${LOG_DIR}/${MODE}_build_${BUILD_NUMBER}_log.txt"
 export GIT_COMMIT=$GIT_COMMIT
 export GIT_PREVIOUS_COMMIT=$GIT_PREVIOUS_COMMIT
 export LOG_DIR=$LOG_DIR


### PR DESCRIPTION
Jenkins runs this code in two contexts: requested via PR and weekly tool updates.  Builds from both contexts have integer build numbers.  Rename log files and jenkins commits to include 'install', 'update' so they unique.