### PR TITLE
ensure that only relevant tests are run during jenkins tool installation

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -309,7 +309,8 @@ test_tool() {
 
   sleep 30s; # Allow threads to catch up so that all files are available for testing
 
-  command="shed-tools test -g $URL -a $API_KEY -t $TOOL_FILE --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
+  TOOL_PARAMS="--name $TOOL_NAME --owner $OWNER --revisions $INSTALLED_REVISION --toolshed $TOOL_SHED_URL"
+  command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
   echo "${command/$API_KEY/<API_KEY>}"
   {
     $command


### PR DESCRIPTION
Currently, if a tool is installed without specified revisions, the test step is running every available test for the tool rather than only those for the revision that is installed.  This might be blocking some new revisions that would pass the tests on their own.