### PR TITLE
script to wait until galaxy is aware of new tool

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -307,7 +307,14 @@ test_tool() {
   TEST_JSON="$TMP/test.json"
   rm -f $TEST_LOG $TEST_JSON ||:;  # delete file if it exists
 
-  sleep 30s; # Allow threads to catch up so that all files are available for testing
+  {
+    python scripts/wait_for_tool.py -g $URL -a $API_KEY -n $TOOL_NAME -o $OWNER -r $INSTALLED_REVISION
+  } || {
+    log_row "Tool not found";
+    log_error $LOG_FILE
+    exit_installation 1
+    return 1
+  }
 
   TOOL_PARAMS="--name $TOOL_NAME --owner $OWNER --revisions $INSTALLED_REVISION --toolshed $TOOL_SHED_URL"
   command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"

--- a/scripts/is_tool_new.py
+++ b/scripts/is_tool_new.py
@@ -6,7 +6,7 @@ from bioblend.galaxy.toolshed import ToolShedClient
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Uninstall tool from a galaxy instance')
+    parser = argparse.ArgumentParser(description='Writes True to stdout if a tool/owner combination does not exist on a Galaxy instance')
     parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL')
     parser.add_argument('-a', '--api_key', help='API key for galaxy server')
     parser.add_argument('-n', '--name', help='Tool name')

--- a/scripts/wait_for_tool.py
+++ b/scripts/wait_for_tool.py
@@ -1,0 +1,51 @@
+import argparse
+import time
+import sys
+
+from bioblend.galaxy import GalaxyInstance
+from bioblend.galaxy.toolshed import ToolShedClient
+
+time_increment = 30
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Wait for a tool revision to appear in a repository list for a Galaxy instance')
+    parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL')
+    parser.add_argument('-a', '--api_key', help='API key for galaxy server')
+    parser.add_argument('-n', '--name', help='Tool name')
+    parser.add_argument('-o', '--owner', help='Tool owner')
+    parser.add_argument('-r', '--revision', help='Changeset revision')
+    parser.add_argument('-t', '--timeout', type=int, default=600, help='Time to wait in seconds')
+
+    args = parser.parse_args()
+    galaxy_url = args.galaxy_url
+    api_key = args.api_key
+    name = args.name
+    owner = args.owner
+    revision = args.revision
+    timeout = args.timeout
+
+    found_tool = False
+    elapsed_sleep = 0
+    while found_tool is False:
+        if elapsed_sleep > timeout:
+            raise Exception('Timeout exceeded')
+        matches = None
+        try:
+            gal = GalaxyInstance(galaxy_url, api_key)
+            cli = ToolShedClient(gal)
+            u_repos = cli.get_repositories()
+            matches = [t for t in u_repos if t['name'] == name and t['owner'] == owner and t['changeset_revision'] == revision]
+        except Exception as e:
+            sys.stderr.write('%s\n' % str(e))
+            # Do nothing and wait for timeout
+        if matches:
+            found_tool = True
+        else:
+            sys.stderr.write('Waiting for tool on galaxy\n')
+            elapsed_sleep += time_increment
+            time.sleep(time_increment)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
On a jenkins job (update 5), tests were running on staging before the (job/web?) handlers were aware of the tools existence, so no tests were run on staging.  This will repeatedly check whether the tool in the list of all repos waiting 30 seconds between tries.  Run this just before testing instead of 'sleep 30'