### PR TITLE
[FORCE] install tools from update 8 that failed due to test data tables

### DIFF
--- a/requests/bcftools_consensus@latest.yml
+++ b/requests/bcftools_consensus@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: bcftools_consensus
+  owner: iuc
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_convert_to_vcf@latest.yml
+++ b/requests/bcftools_convert_to_vcf@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: bcftools_convert_to_vcf
+  owner: iuc
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_stats@latest.yml
+++ b/requests/bcftools_stats@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: bcftools_stats
+  owner: iuc
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/fasta_compute_length@latest.yml
+++ b/requests/fasta_compute_length@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: fasta_compute_length
+  owner: devteam
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/gemini_load@latest.yml
+++ b/requests/gemini_load@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: gemini_load
+  owner: iuc
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/kallisto_pseudo@latest.yml
+++ b/requests/kallisto_pseudo@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: kallisto_pseudo
+  owner: iuc
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/kraken@latest.yml
+++ b/requests/kraken@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: kraken
+  owner: devteam
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/rgrnastar@latest.yml
+++ b/requests/rgrnastar@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: rgrnastar
+  owner: iuc
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/snippy@latest.yml
+++ b/requests/snippy@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: snippy
+  owner: iuc
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/stringtie@latest.yml
+++ b/requests/stringtie@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: stringtie
+  owner: iuc
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Tests that come with their own test data tables will not pass automated tests according to https://planemo.readthedocs.io/en/latest/writing_how_do_i.html#test-index-loc-data
These tools are only failing the tests that depend on data tables.

bcftools_consensus (2/3)
bcftools_convert_to_vcf (5/7)
bcftools_stats (2/3)
fasta_compute_length (3/5)
gemini_load (0/5)
kallisto_pseudo (4/5)
kraken (0/2)
rgrnastar (9/11)
snippy (7/9)
stringtie (11/12)