### PR TITLE
add check for repository status when updating

### DIFF
--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -41,10 +41,6 @@ else
 fi
 
 LOG_DIR=${LOG_DIR}/${MODE}_build_${BUILD_NUMBER}
-[ -d $LOG_DIR ] || mkdir -p $LOG_DIR;
-mkdir -p $LOG_DIR/staging;  # staging test json output
-mkdir -p $LOG_DIR/production;  # production test json output
-mkdir -p $LOG_DIR/planemo;  # planemo html output tools that fail tests
 
 export BUILD_NUMBER=$BUILD_NUMBER
 export LOG_FILE="${LOG_DIR}/install_log.txt"
@@ -104,6 +100,12 @@ jenkins_tool_installation() {
       echo $REQUEST_FILES;
     fi
   fi
+
+  # Create log folder structure
+  [ -d $LOG_DIR ] || mkdir -p $LOG_DIR;
+  mkdir -p $LOG_DIR/staging;  # staging test json output
+  mkdir -p $LOG_DIR/production;  # production test json output
+  mkdir -p $LOG_DIR/planemo;  # planemo html output tools that fail tests
 
   activate_virtualenv
   echo "Saving output to $LOG_FILE"

--- a/scripts/is_tool_new.py
+++ b/scripts/is_tool_new.py
@@ -21,7 +21,7 @@ def main():
     gal = GalaxyInstance(galaxy_url, api_key)
     cli = ToolShedClient(gal)
     u_repos = cli.get_repositories()
-    tools_with_name_and_owner = [t for t in u_repos if t['name'] == name and t['owner'] == owner]
+    tools_with_name_and_owner = [t for t in u_repos if t['name'] == name and t['owner'] == owner and t['status'] == 'Installed']
     if not tools_with_name_and_owner:
         sys.stdout.write('True')  # we did not find the name/owner combination so we say that the tool is new
     else:

--- a/scripts/organise_request_files.py
+++ b/scripts/organise_request_files.py
@@ -3,7 +3,6 @@ import argparse
 import sys
 import os
 
-
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.toolshed import ToolShedClient
 from bioblend.toolshed import ToolShedInstance

--- a/scripts/organise_request_files.py
+++ b/scripts/organise_request_files.py
@@ -3,50 +3,13 @@ import argparse
 import sys
 import os
 
+
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.toolshed import ToolShedClient
 from bioblend.toolshed import ToolShedInstance
-from bioblend.toolshed.repositories import ToolShedRepositoryClient as bioblend_ToolShedRepositoryClient
+from bioblend.toolshed.repositories import ToolShedRepositoryClient
 
 trusted_owners_file = 'trusted_owners.yml'
-
-
-class ToolShedRepositoryClient(bioblend_ToolShedRepositoryClient):
-    # Subclass bioblend object in order to access /updates endpoint
-    def updates(self, name, owner, revision, hexlify=False):
-        """
-        Return a dictionary with boolean values for whether there are updates
-        available for the repository revision, newer installable revisions
-        available, the revision is the latest installable revision, and if the
-        repository is deprecated.
-
-        :type name: str
-        :param name: the name of the repository
-
-        :type owner: str
-        :param owner: the owner of the repository
-
-        :type revision: str
-        :param revision: the revision to test updatability against
-
-        :type hexlify: bool
-        :param hexlify: whether to hexlify response
-
-        :rtype: dict
-        :return: Dict containing boolean values for keys
-          'latest_installable_revision', 'revision_update', 'revision_upgrade',
-          'repository_deprecated'
-        """
-        url = self.url + '/updates'
-        params = {
-            'name': name,
-            'owner': owner,
-            'changeset_revision': revision,
-            'hexlify': hexlify,
-        }
-        r = self._get(url=url, params=params)
-
-        return r
 
 
 def main():
@@ -99,6 +62,7 @@ def main():
         gal = GalaxyInstance(production_url, production_api_key)
         cli = ToolShedClient(gal)
         u_repos = cli.get_repositories()
+        installed_repos = [r for r in u_repos if r['status'] == 'Installed']  # Skip deactivated repos
 
         trusted_tools = [t for t in tools if is_trusted_tool(trusted_owners, t)]
         sys.stderr.write('Checking for updates from %d tools\n' % len(trusted_tools))
@@ -106,11 +70,12 @@ def main():
         for i, tool in enumerate(trusted_tools):
             if i > 0 and i % 100 == 0:
                 sys.stderr.write('%d/%d\n' % (i, len(trusted_tools)))
-            if not latest_revision_installed(u_repos, tool):
+            if not latest_revision_installed(installed_repos, tool):
                 extraneous_keys = [key for key in tool.keys() if key not in ['name', 'owner', 'tool_panel_section_label', 'tool_shed_url']]
                 for key in extraneous_keys:  # delete extraneous keys, we want latest revision
                     del tool[key]
                 tools.append(tool)
+        sys.stderr.write('%d tools with updates available\n' % len(tools))
 
     for tool in tools:
         if 'revisions' in tool.keys() and len(tool['revisions']) > 1:
@@ -134,19 +99,18 @@ def is_trusted_tool(trusted_owners, tool):
 
 
 def latest_revision_installed(repos, tool):
-    matching_repos = [r for r in repos if r['name'] == tool['name'] and r['owner'] == tool['owner'] and r['changeset_revision'] in tool['revisions']]
     toolshed = ToolShedInstance(url='https://' + tool['tool_shed_url'])
     repo_client = ToolShedRepositoryClient(toolshed)
+    matching_repos = [r for r in repos if r['name'] == tool['name'] and r['owner'] == tool['owner']]
 
-    for mr in matching_repos:
-        try:
-            tool_shed_status = repo_client.updates(mr['name'], mr['owner'], mr['changeset_revision'])
-        except Exception as e:
-            sys.stderr.write('Skipping %s.  Error querying toolshed: %s\n' % (tool['name'], str(e)))
-            return True  # return True so that update will be skipped.
-        if tool_shed_status.get('latest_installable_revision') == 'True':
-            return True
-    return False
+    if not matching_repos:
+        return True
+    try:
+        latest_revision = repo_client.get_ordered_installable_revisions(tool['name'], tool['owner'])[-1]
+    except Exception as e:
+        sys.stderr.write('Skipping %s.  Error querying tool revisions for: %s\n' % (tool['name'], str(e)))
+        return True
+    return latest_revision in [r['changeset_revision'] for r in matching_repos]
 
 
 def write_output_file(path, tool):


### PR DESCRIPTION
Jenkins has been trying to update kraken_filter which is deactivated on galaxy.  Add a check to prevent update of tools that are not active.
Change method for deciding whether to update
(Hopefully) fix check for whether a tool is new or not.