### PR TITLE
revert to running all tests for updates

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -313,14 +313,13 @@ test_tool() {
   TEST_LOG="$TMP/test_log.txt"
   rm -f $TEST_LOG ||:;  # delete file if it exists
 
-  sleep 180s; # Allow time for handlers to catch up
+  sleep 120s; # Allow time for handlers to catch up
 
   # Ping galaxy url
   echo "Waiting for $URL";
   galaxy-wait -g $URL
 
-  TOOL_PARAMS="--name $TOOL_NAME --owner $OWNER --revisions $INSTALLED_REVISION --toolshed $TOOL_SHED_URL"
-  command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
+  command="shed-tools test -g $URL -a $API_KEY -t $TOOL_FILE --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
   echo "${command/$API_KEY/<API_KEY>}"
   {
     $command


### PR DESCRIPTION
Instead of passing the installed revision hash to `shed-tools test`, allow it to run all tests for an updated tool.  The reason for this is that if a new revision has been added but the tool version is the same, the tool panel will remain unchanged and shed-tools will not be able to locate tests for the new revision hash.