### PR TITLE
specific tool versions for tutorial Pre-processing of Single-Cell RNA

### DIFF
--- a/requests/scrna_versions.yml
+++ b/requests/scrna_versions.yml
@@ -1,0 +1,25 @@
+tools:
+- name: umi_tools_extract
+  owner: iuc
+  revisions:
+  - 828dba98cdb4
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rgrnastar
+  owner: iuc
+  revisions:
+  - 2055c2667eb3
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: featurecounts
+  owner: iuc
+  revisions:
+  - f3a5f075498f
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: umi_tools_count
+  owner: iuc
+  revisions:
+  - b557acca0b56
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Usually a workflow can be run on Galaxy if we have the tool of any version.  If the workflow contains subworkflows, the algorithm that loads subworkflow steps will raise an exception for any tool version mismatch, and the workflow cannot be loaded.