### PR TITLE
[FORCE] install tools abricate, ivar_trim, fastp (failed in update_12)

### DIFF
--- a/requests/abricate@latest.yml
+++ b/requests/abricate@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: abricate
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/fastp@latest.yml
+++ b/requests/fastp@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: fastp
+  owner: iuc
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ivar_trim@latest.yml
+++ b/requests/ivar_trim@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: ivar_trim
+  owner: iuc
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
- abricate failed due to filepaths being on pulsar but passed everything on staging
- fastp passed 10/11, failed one due to unexpected file extension (expected [fastqsanger] but found [fastq])
- ivar_trim passed 3/4, failed one due to the test using test data tables