### PR TITLE
[FORCE] install tool jbrowse

### DIFF
--- a/requests/jbrowse@latest.yml
+++ b/requests/jbrowse@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: jbrowse
+  owner: iuc
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Passes 9/10 tests, one fails because of filepaths in the history file, the previous revision was force-installed for the same reason