### PR TITLE
update organise_request_files, trusted_owners, use common virtualenv for Jenkins jobs

### DIFF
--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -100,6 +100,8 @@ def key_check(loaded_files):
                 # Prevent people from having both label and id specified as this
                 # can lead to tools being installed outside of sections
                 raise Exception('Error in %s: tool_panel_section_id must not be specified.  Use tool_panel_section_label only.')
+            if 'skip_tests' in tool.keys():
+                raise Exception('skip_tests option not allowed.')
             label = tool['tool_panel_section_label']
             if label not in valid_section_labels:
                 raise Exception('Error in %s:  tool_panel_section_label %s is not valid' % (loaded_file['filename'], label))

--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -54,12 +54,15 @@ export FORCE=$FORCE
 activate_virtualenv() {
   # Activate the virtual environment on jenkins. If this script is being run for
   # the first time we will need to set up the virtual environment
-  # The venv is set up a level below the workspace so that we do not have
-  # to rebuild it each time the script is run
-  VIRTUALENV="../.venv3"
-  REQUIREMENTS_FILE="jenkins/requirements.txt"
-  CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.txt"
+  # The venv is set up in Jenkins' home directory so that we do not have
+  # to rebuild it each time and multiple jobs can share it
+  VENV_PATH="/var/lib/jenkins/jobs_common"
+  [ $LOCAL_ENV = 1 ] && VENV_PATH=".."
+  VIRTUALENV="$VENV_PATH/.venv3"
+  REQUIREMENTS_FILE="jenkins/requirements.yml"
+  CACHED_REQUIREMENTS_FILE="$VIRTUALENV/cached_requirements.yml"
 
+  [ ! -d $VENV_PATH ] && mkdir $VENV_PATH
   [ ! -d $VIRTUALENV ] && virtualenv -p python3 $VIRTUALENV
   # shellcheck source=../.venv3/bin/activate
   . "$VIRTUALENV/bin/activate"

--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -1,5 +1,6 @@
-
 pyyaml
 -e git+https://github.com/cat-bro/ephemeris.git@master#egg=ephemeris
 bioblend==0.13.0
 planemo==0.70.0
+# requirements for galaxy virtualenv also required here for tests to run correctly
+pysam==0.15.2

--- a/scripts/organise_request_files.py
+++ b/scripts/organise_request_files.py
@@ -1,6 +1,5 @@
 import yaml
 import argparse
-import sys
 import os
 
 from bioblend.galaxy import GalaxyInstance
@@ -34,10 +33,10 @@ def main():
     production_api_key = args.production_api_key
 
     if not (files or source_dir):
-        sys.stderr.write('either --files or --source_directory must be defined as an argument\n')
+        print('either --files or --source_directory must be defined as an argument\n')
         return
     elif files and source_dir:
-        sys.stderr.write('--files and --source_directory have both been provided.  Ignoring source_directory in favour of files\n')
+        print('--files and --source_directory have both been provided.  Ignoring source_directory in favour of files\n')
     if source_dir and not files:
         files = ['%s/%s' % (source_dir, name) for name in os.listdir(source_dir)]
 
@@ -58,23 +57,26 @@ def main():
             trusted_owners = yaml.safe_load(infile.read())['trusted_owners']
 
         # load repository data to check which tools have updates available
-        gal = GalaxyInstance(production_url, production_api_key)
-        cli = ToolShedClient(gal)
-        u_repos = cli.get_repositories()
-        installed_repos = [r for r in u_repos if r['status'] == 'Installed']  # Skip deactivated repos
+        galaxy_instance = GalaxyInstance(production_url, production_api_key)
+        toolshed_client = ToolShedClient(galaxy_instance)
+        repos = toolshed_client.get_repositories()
+        installed_repos = [r for r in repos if r['status'] == 'Installed']  # Skip deactivated repos
 
-        trusted_tools = [t for t in tools if is_trusted_tool(trusted_owners, t)]
-        sys.stderr.write('Checking for updates from %d tools\n' % len(trusted_tools))
+        trusted_tools = [t for t in tools if [o for o in trusted_owners if t['owner'] == o['owner']] != []]
+        print('Checking for updates from %d tools' % len(trusted_tools))
         tools = []
         for i, tool in enumerate(trusted_tools):
             if i > 0 and i % 100 == 0:
-                sys.stderr.write('%d/%d\n' % (i, len(trusted_tools)))
-            if not latest_revision_installed(installed_repos, tool):
+                print('%d/%d' % (i, len(trusted_tools)))
+            new_revision_info = get_new_revision(tool, installed_repos, trusted_owners)
+            # if tool_has_new_revision(tool, installed_repos, trusted_owners):
+            if new_revision_info:
                 extraneous_keys = [key for key in tool.keys() if key not in ['name', 'owner', 'tool_panel_section_label', 'tool_shed_url']]
-                for key in extraneous_keys:  # delete extraneous keys, we want latest revision
+                for key in extraneous_keys:
                     del tool[key]
+                tool.update(new_revision_info)
                 tools.append(tool)
-        sys.stderr.write('%d tools with updates available\n' % len(tools))
+        print('%d tools with updates available' % len(tools))
 
     for tool in tools:
         if 'revisions' in tool.keys() and len(tool['revisions']) > 1:
@@ -86,39 +88,65 @@ def main():
             write_output_file(path=path, tool=tool)
 
 
-def is_trusted_tool(trusted_owners, tool):
-    trusted = False
+def get_new_revision(tool, repos, trusted_owners):
     matching_owners = [o for o in trusted_owners if tool['owner'] == o['owner']]
-    if matching_owners:
-        [owner] = matching_owners
-        blacklist = owner.get('blacklist') if isinstance(owner, dict) else None
-        if not blacklist or tool['name'] not in blacklist:
-            trusted = True
-    return trusted
+    if not matching_owners:
+        return
+    [owner] = matching_owners
+    blacklist = owner.get('blacklist', []) if isinstance(owner, dict) else []
+    blacklisted_revisions = [b.get('revision', 'all') for b in blacklist if b.get('name') == tool['name']]
+    if 'all' in blacklisted_revisions:
+        return
 
-
-def latest_revision_installed(repos, tool):
     toolshed = ToolShedInstance(url='https://' + tool['tool_shed_url'])
     repo_client = ToolShedRepositoryClient(toolshed)
     matching_repos = [r for r in repos if r['name'] == tool['name'] and r['owner'] == tool['owner']]
-
     if not matching_repos:
-        return True
+        return
+
     try:
         latest_revision = repo_client.get_ordered_installable_revisions(tool['name'], tool['owner'])[-1]
     except Exception as e:
-        sys.stderr.write('Skipping %s.  Error querying tool revisions for: %s\n' % (tool['name'], str(e)))
-        return True
-    return latest_revision in [r['changeset_revision'] for r in matching_repos]
+        print('Skipping %s.  Error querying tool revisions: %s' % (tool['name'], str(e)))
+        return
+
+    blacklisted = latest_revision in blacklisted_revisions
+    installed = latest_revision in [r['changeset_revision'] for r in matching_repos]
+    if blacklisted or installed:
+        return
+
+    def get_version(revision):
+        try:
+            data = repo_client.get_repository_revision_install_info(tool['name'], tool['owner'], revision)
+            repository, metadata, install_info = data
+            version = metadata['valid_tools'][0]['version']
+            return version
+        except Exception as e:
+            print('Skipping %s.  Error querying tool revisions: %s' % (tool['name'], str(e)))
+
+    latest_revision_version = get_version(latest_revision)
+    installed_versions = [get_version(r['changeset_revision']) for r in matching_repos]
+    if latest_revision_version is None or None in installed_versions:  # skip on errors from get_version
+        return
+    skip_tests = latest_revision_version in installed_versions
+    if skip_tests:
+        print('Latest revision %s of %s has version %s already installed on GA.  Skipping tests for this tool ' % (
+            latest_revision, tool['name'], latest_revision_version
+        ))
+
+    return {'revisions': [latest_revision], 'skip_tests': skip_tests}
 
 
 def write_output_file(path, tool):
     if not path[-1] == '/':
         path = path + '/'
     [revision] = tool['revisions'] if 'revisions' in tool.keys() else ['latest']
+    skip_tests = tool.pop('skip_tests', False)
     file_path = '%s%s@%s.yml' % (path, tool['name'], revision)
-    sys.stderr.write('writing file %s\n' % file_path)
+    print('writing file %s' % file_path)
     with open(file_path, 'w') as outfile:
+        if skip_tests:
+            outfile.write('# [SKIP_TESTS]\n')
         outfile.write(yaml.dump({'tools': [tool]}))
 
 

--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -1,11 +1,12 @@
 ---
 # List of trusted tool owners.  The weekly update script will install updates for
 # any installed tools on usegalaxy.org.au with owners on this list, with the exception
-# of tools named in the blacklist for the owner.
+# of tools named in the blacklist for the owner.  A tool can be excluded by name
+# or by name and revision
 trusted_owners:
 - owner: iuc
   blacklist:
-  - gatk2
+  - name: gatk2
 - owner: simon-gladman
 - owner: nml
 - owner: bgruening


### PR DESCRIPTION
The organise_request_files.py that checks for new revisions also does a version check now.  If a new revision comes without a version bump we cannot test it in shed-tools and we must not uninstall it because we would remove an existing version (https://github.com/usegalaxy-au/usegalaxy-au-tools/issues/157).  The output request file for the tool has `# [SKIP_TESTS]` prepended.

trusted_tools.yml has been altered slightly to allow a specific revision of a tool to be blacklisted.

Including pysam in jenkins requirements means that some test that previously failed will pass.  There are 3 jenkins jobs using exactly the same .venv setup so this is being moved to ~/jobs_common.  It doesn’t matter if this gets wiped out in a jenkins update, the script will recreate it.
