### PR TITLE
Save installation log as a temporary file, make sure SKIP_TESTS and FORCE follow the same logic

### DIFF
--- a/.travis/check_files.py
+++ b/.travis/check_files.py
@@ -9,6 +9,7 @@ from bioblend.toolshed.repositories import ToolShedRepositoryClient
 default_tool_shed = 'toolshed.g2.bx.psu.edu'
 
 mandatory_keys = ['name', 'tool_panel_section_label', 'owner']
+valid_keys = mandatory_keys + ['revisions', 'tool_shed_url']
 
 valid_section_labels = [
     'Get Data', 'Send Data', 'Collection Operations', 'Text Manipulation',
@@ -33,7 +34,6 @@ def main():
     parser.add_argument('-g', '--production_url', help='Galaxy production server URL')
     parser.add_argument('-s', '--staging_dir', help='Staging server tool file directory')
     parser.add_argument('-p', '--production_dir', help='Production server tool file directory')
-
 
     args = parser.parse_args()
     files = args.files
@@ -100,8 +100,9 @@ def key_check(loaded_files):
                 # Prevent people from having both label and id specified as this
                 # can lead to tools being installed outside of sections
                 raise Exception('Error in %s: tool_panel_section_id must not be specified.  Use tool_panel_section_label only.')
-            if 'skip_tests' in tool.keys():
-                raise Exception('skip_tests option not allowed.')
+            for key in tool.keys():
+                if key not in valid_keys:
+                    raise Exception('%s is not a valid key.  Valid keys are [%s]' % (key, ', '.join(valid_keys)))
             label = tool['tool_panel_section_label']
             if label not in valid_section_labels:
                 raise Exception('Error in %s:  tool_panel_section_label %s is not valid' % (loaded_file['filename'], label))

--- a/jenkins/report.sh
+++ b/jenkins/report.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
-VIRTUALENV="../.venv3"
+SECRET_ENV_FILE=".secret.env"; # todo: run this script from within main.sh
+[ -f $SECRET_ENV_FILE ] && LOCAL_ENV=1 || LOCAL_ENV=0
+[ $LOCAL_ENV = 0 ] && VENV_PATH="/var/lib/jenkins/jobs_common" || VENV_PATH=".."
+VIRTUALENV="$VENV_PATH/.venv3"
 # shellcheck source=../.venv/bin/activate
 . "$VIRTUALENV/bin/activate"
 


### PR DESCRIPTION
The tools with [SKIP_TESTS] were not being logged in the update ... this will fix that.  The entries for the .tsv file have been stored in memory which is a bad idea if the script ever has to be stopped in the middle.