### PR TITLE
blacklist deeptools_bam_pe_fragmentsize

### DIFF
--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -10,4 +10,7 @@ trusted_owners:
 - owner: simon-gladman
 - owner: nml
 - owner: bgruening
+  blacklist:
+  - name: deeptools_bam_pe_fragmentsize
+    revision: 62eb6d63f582
 - owner: devteam


### PR DESCRIPTION
This revision of deeptools_bam_pe_fragmentsize fails tests because it depends on the wrong version of matplotlib.  They have already fixed this in the development repo and there will probably be a new revision soon