### PR TITLE
retry tools blockclust, pathview (failed in install_284)

### DIFF
--- a/requests/blockclust@latest.yml
+++ b/requests/blockclust@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: blockclust
+  owner: rnateam
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/pathview@latest.yml
+++ b/requests/pathview@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: pathview
+  owner: iuc
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
pathview failed to install while Galaxy was under heavy load, blockclust had a strange test failure on production where blockclust.py couldn't be found