### PR TITLE
[FORCE] install tools dropletutils, goenrichment (failed in install 284)

### DIFF
--- a/requests/dropletutils@latest.yml
+++ b/requests/dropletutils@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: dropletutils
+  owner: iuc
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/goenrichment@latest.yml
+++ b/requests/goenrichment@latest.yml
@@ -1,0 +1,5 @@
+tools:
+- name: goenrichment
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
dropletutils fails tests that compare .png files that look identical, might be some differences in font size of plot labels
goenrichment fails diff because output has '1.94e-5' instead of '1.94E-5'
