### PR TITLE
[FORCE] install some tools from update 18

### DIFF
--- a/requests/bp_genbank2gff3@11c3eb512633.yml
+++ b/requests/bp_genbank2gff3@11c3eb512633.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bp_genbank2gff3
+  owner: iuc
+  revisions:
+  - 11c3eb512633
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/cat_bins@18676df0cb3a.yml
+++ b/requests/cat_bins@18676df0cb3a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: cat_bins
+  owner: iuc
+  revisions:
+  - 18676df0cb3a
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_gemini_database_downloader@5bcf0e24f42c.yml
+++ b/requests/data_manager_gemini_database_downloader@5bcf0e24f42c.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_gemini_database_downloader
+  owner: iuc
+  revisions:
+  - 5bcf0e24f42c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/scanpy_cluster_reduce_dimension@b2df381a6004.yml
+++ b/requests/scanpy_cluster_reduce_dimension@b2df381a6004.yml
@@ -1,0 +1,7 @@
+tools:
+- name: scanpy_cluster_reduce_dimension
+  owner: iuc
+  revisions:
+  - b2df381a6004
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
- bp_genbank2gff3 should have passed, failed on uploads of test data with gateway timeouts
- data_manager_gemini_database_downloader cannot be tested with shed-tools
- cat_bins cannot be tested (all tests use data tables)
- scanpy_cluster_reduce_dimension fails one test on an optional dependency (passes 9/10 tests)