### PR TITLE
more tools for sequence-analysis tutorials

### DIFF
--- a/requests/sequence-analysis.yml
+++ b/requests/sequence-analysis.yml
@@ -1,0 +1,31 @@
+tools:
+- name: fastqc
+  owner: devteam
+  revisions:
+  - ff9530579d1f
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: multiqc
+  owner: iuc
+  revisions:
+  - 1c2db0054039
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bowtie2
+  owner: devteam
+  revisions:
+  - 17062a0decb7
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: jbrowse
+  owner: iuc
+  revisions:
+  - 1cfc579079a6
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cutadapt
+  owner: lparsons
+  revisions:
+  - 660cffd8d92a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
The workflows will run with the versions on GA but the specific tool versions from the workflows are needed in order to be able to load and test them through the API.