### PR TITLE
Revert to continuing installation if tool has no tests

### DIFF
--- a/jenkins/main.sh
+++ b/jenkins/main.sh
@@ -5,7 +5,6 @@ MODE="$1"; # Two modes possible: "install" for tool request, "update" for cron u
 ARGS=( "$@" )
 FILE_ARGS=("${ARGS[@]:1}")
 LOG_DIR=~/galaxy_tool_automation
-BASH_V="$(echo ${BASH_VERSION} | head -c 1)" # this will be "4" if the bash version is 4.x, empty otherwise
 
 FORCE=0
 GIT_COMMIT_MESSAGE=$(git log --format=%B -n 1 $GIT_COMMIT | cat)
@@ -47,7 +46,6 @@ export LOG_FILE="${LOG_DIR}/install_log.txt"
 export GIT_COMMIT=$GIT_COMMIT
 export GIT_PREVIOUS_COMMIT=$GIT_PREVIOUS_COMMIT
 export LOG_DIR=$LOG_DIR
-export BASH_V=$BASH_V
 export MODE=$MODE
 export FORCE=$FORCE
 

--- a/scripts/first_match_regex.py
+++ b/scripts/first_match_regex.py
@@ -2,6 +2,13 @@ import re
 import argparse
 import sys
 
+"""
+Find the first match from a pattern in a file.  This is designed to mimic
+the functionality of bash regular expression matching.  This helper has been
+written because bash versions earlier than 4 do not support regex matching.
+"""
+
+
 def main():
     parser = argparse.ArgumentParser(description='Mimic bash pattern matching')
     parser.add_argument('-p', '--pattern', help='Pattern to match')
@@ -10,9 +17,8 @@ def main():
 
     first_match_regex(args.file_path, args.pattern)
 
+
 def first_match_regex(path, pattern):
-    # Hack to produce the same values that would be stored in BASH_REMATCH[1:] if
-    # it were working on mac.
     compiled_pattern = re.compile(
         pattern,
         re.MULTILINE,
@@ -23,4 +29,6 @@ def first_match_regex(path, pattern):
         match = matches[0] if not isinstance(matches[0], str) else [matches[0]]
         sys.stdout.write('%s' % ' '.join(match))  # value returned to shell through stdout
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/organise_request_files.py
+++ b/scripts/organise_request_files.py
@@ -128,25 +128,25 @@ def get_new_revision(tool, repos, trusted_owners):
     installed_versions = [get_version(r['changeset_revision']) for r in matching_repos]
     if latest_revision_version is None or None in installed_versions:  # skip on errors from get_version
         return
-    skip_tests = latest_revision_version in installed_versions
-    if skip_tests:
+    version_update = latest_revision_version in installed_versions
+    if version_update:
         print('Latest revision %s of %s has version %s already installed on GA.  Skipping tests for this tool ' % (
             latest_revision, tool['name'], latest_revision_version
         ))
 
-    return {'revisions': [latest_revision], 'skip_tests': skip_tests}
+    return {'revisions': [latest_revision], 'version_update': version_update}
 
 
 def write_output_file(path, tool):
     if not path[-1] == '/':
         path = path + '/'
     [revision] = tool['revisions'] if 'revisions' in tool.keys() else ['latest']
-    skip_tests = tool.pop('skip_tests', False)
+    version_update = tool.pop('version_update', False)
     file_path = '%s%s@%s.yml' % (path, tool['name'], revision)
     print('writing file %s' % file_path)
     with open(file_path, 'w') as outfile:
-        if skip_tests:
-            outfile.write('# [SKIP_TESTS]\n')
+        if version_update:
+            outfile.write('# [VERSION_UPDATE]\n')
         outfile.write(yaml.dump({'tools': [tool]}))
 
 

--- a/scripts/uninstall_tools.py
+++ b/scripts/uninstall_tools.py
@@ -1,27 +1,25 @@
+import argparse
+
 from bioblend.galaxy import GalaxyInstance
 from bioblend.galaxy.toolshed import ToolShedClient
-import argparse
-import yaml
-import os
-import sys
 
 """
 Uninstall tools from a galaxy instance via the API using the bioblend package.
-This can be used to uninstall any galaxy toolshed tool.  The main use case is
-when a tool has been installed incorrectly or when an error has occurred during
-installation causing the tool to be partially installed.
+Can be used to uninstall any galaxy toolshed tool with the exception of
+data managers.
 """
 
 
 def main():
     parser = argparse.ArgumentParser(description='Uninstall tool from a galaxy instance')
-    parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL')
-    parser.add_argument('-a', '--api_key', help='API key for galaxy server')
+    parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL', required=True)
+    parser.add_argument('-a', '--api_key', help='API key for galaxy server', required=True)
     parser.add_argument(
         '-n',
         '--names',
         help='Names of tools to uninstall.  These can include revision hashes e.g. --names name1@revision1 name1@revision2 name2 ',
         nargs='+',
+        required=True,
     )
     parser.add_argument(
         '-f',
@@ -31,64 +29,45 @@ def main():
     )
 
     args = parser.parse_args()
-    galaxy_url = args.galaxy_url
-    api_key = args.api_key
-    names = args.names
-    force = args.force
-
-    if not names:
-        raise Exception('Arguments --names (-n) must be provided.')
-
-    uninstall_tools(galaxy_url, api_key, names, force)
+    uninstall_tools(args.galaxy_url, args.api_key, args.names, args.force)
 
 
 def uninstall_tools(galaxy_server, api_key, names, force):
+    tools_to_uninstall = []
     galaxy_instance = GalaxyInstance(url=galaxy_server, key=api_key)
     toolshed_client = ToolShedClient(galaxy_instance)
-
-    temp_tool_list_file = 'tmp/installed_tool_list.yml'
-    # TODO: Switch to using bioblend to obtain this list
-    # ephemeris uses bioblend but without using ephemeris we cut out the need to for a temp file
-    os.system('get-tool-list -g %s -a %s -o %s --get_all_tools' % (galaxy_server, api_key, temp_tool_list_file))
-
-    tools_to_uninstall = []
-    with open(temp_tool_list_file) as tool_file:
-        installed_tools = yaml.safe_load(tool_file.read())['tools']
-    if not installed_tools:
-        raise Exception('No tools to uninstall')
-    os.system('rm %s' % temp_tool_list_file)
+    installed_tools = [t for t in toolshed_client.get_repositories() if t['status'] != 'Uninstalled']
 
     for name in names:
         revision = None
         if '@' in name:
             (name, revision) = name.split('@')
-        matching_tools = [t for t in installed_tools if t['name'] == name and (not revision or revision in t['revisions'])]
+        matching_tools = [t for t in installed_tools if (
+            t['name'] == name and (not revision or revision == t['changeset_revision'])
+        )]
+        id_string = 'name %s revision %s' % (name, revision) if revision else 'name %s' % name
         if len(matching_tools) == 0:
-            id_string = 'name %s revision %s' % (name, revision) if revision else 'name %s' % name
-            sys.stderr.write('*** Warning: No tool with %s\n' % id_string)
+            print('*** Warning: No tool with %s' % id_string)
         elif len(matching_tools) > 1 and not force:
-            sys.stderr.write(
-                '*** Warning: More than one toolshed tool found for %s.  ' % name
-                + 'Not uninstalling any of these tools.  Run script with --force (-f) flag to uninstall anyway\n'
+            print(
+                '*** Warning: More than one toolshed tool found for %s.  ' % id_string
+                + 'Not uninstalling any of these tools.  Run script with --force (-f) flag to uninstall anyway'
             )
         else:  # Either there is only one matching tool for the name and revision, or there are many and force=True
-            for tool in matching_tools:
-                tool_copy = tool.copy()
-                if revision:
-                    tool_copy['revisions'] = [revision]
-                tools_to_uninstall.append(tool_copy)
+            tools_to_uninstall.extend(matching_tools)
 
     for tool in tools_to_uninstall:
         try:
-            name = tool['name']
-            owner = tool['owner']
-            tool_shed_url = tool['tool_shed_url']
-            revision = tool['revisions'][0]
-            sys.stderr.write('Uninstalling %s at revision %s\n' % (name, revision))
-            return_value = toolshed_client.uninstall_repository_revision(name=name, owner=owner, changeset_revision=revision, tool_shed_url=tool_shed_url)
-            sys.stderr.write(str(return_value) + '\n')
-        except KeyError as e:
-            sys.stderr.write(e)
+            print('Uninstalling %s at revision %s' % (tool['name'], tool['changeset_revision']))
+            return_value = toolshed_client.uninstall_repository_revision(
+                name=tool['name'],
+                owner=tool['owner'],
+                changeset_revision=tool['changeset_revision'],
+                tool_shed_url=tool['tool_shed'],
+            )
+            print(return_value)
+        except Exception as e:
+            print(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Revert to continuing installation if tool has no tests
- Update uninstall_tools.py to use bioblend instead of ephemeris
- Replace SKIP_TESTS value coming in from organise_request_files.py with VERSION_UPDATE. This is used so that jenkins knows not only to skip tests, but to not uninstall the tool under any circumstances.
- Reduce pre-test sleep to 90 seconds.
- Get rid of the bash version check, just use the python helper instead of bash regex