### PR TITLE
[FORCE] install some tools that failed update 20 + Peptide Shaker

### DIFF
--- a/requests/ivar_trim@5d6ed46cc101.yml
+++ b/requests/ivar_trim@5d6ed46cc101.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ivar_trim
+  owner: iuc
+  revisions:
+  - 5d6ed46cc101
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/lofreq_call@074d44697036.yml
+++ b/requests/lofreq_call@074d44697036.yml
@@ -1,0 +1,7 @@
+tools:
+- name: lofreq_call
+  owner: iuc
+  revisions:
+  - 074d44697036
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/minimap2@8c6cd2650d1f.yml
+++ b/requests/minimap2@8c6cd2650d1f.yml
@@ -1,0 +1,7 @@
+tools:
+- name: minimap2
+  owner: iuc
+  revisions:
+  - 8c6cd2650d1f
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/peptideshaker@7fdd9119cc4f.yml
+++ b/requests/peptideshaker@7fdd9119cc4f.yml
@@ -1,0 +1,7 @@
+tools:
+- name: peptideshaker
+  owner: galaxyp
+  revisions:
+  - 7fdd9119cc4f
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
- minimap2 failed due to test data tables
- ivar_trim failed due to test data tables
- peptide shaker failed due the compared output file containing file paths
- lofreq_call has one test where the output is different to what is expected.  In this case it looks like the test-data expected VCF file might be incorrect.  The test output is like the expected output but with more fields in the INFO column (subset pasted below)

```
- expected test output
+ test output
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-pBR322	725	.	G	GN	0	.	;HRUN=1
-pBR322	746	.	A	AN	0	.	;HRUN=1
+pBR322	725	.	G	GN	0	.	DP=46;AF=0.021739;SB=0;DP4=22,23,0,1;INDEL;HRUN=1
+pBR322	746	.	A	AN	0	.	DP=225;AF=0.004444;SB=3;DP4=116,108,0,1;INDEL;HRUN=1
```
