### PR TITLE
cat tools

### DIFF
--- a/requests/cat_tools.yml
+++ b/requests/cat_tools.yml
@@ -1,0 +1,22 @@
+tools:
+- name: data_manager_cat
+  owner: iuc
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_contigs
+  owner: iuc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_add_names
+  owner: iuc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_summarise
+  owner: iuc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_prepare
+  owner: iuc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+


### PR DESCRIPTION
We added cat_bins for some Galaxy Europe proteomics workflows about a month back, not realising that this needs a database, data manager and ideally the other tools in the set.  A user sent a helpdesk ticket because they wanted to use cat_bins but there is no database.  https://support.ehelp.edu.au/a/tickets/82681