### PR TITLE
skip sra_tools until the data type is available (20.05)

### DIFF
--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -34,6 +34,8 @@ trusted_owners:
   - name: gemini_comp_hets
   - name: raxml
     revision: 73a469f7dc96
+  - name: sra_tools # block update of sra_tools until we have galaxy 20.05
+    revision: 964579f93c54 # because it uses a data type introduced in 20.05
 - owner: simon-gladman
 - owner: nml
 - owner: bgruening


### PR DESCRIPTION
Jenkins tried to update this last week but the tests failed because a data type sra_manifest.tabular does not exist pre-20.05.