### PR TITLE
Install version 1.36.1.0 of mothur_sub_sample

### DIFF
--- a/requests/older_mothur_sub_sample.yml
+++ b/requests/older_mothur_sub_sample.yml
@@ -1,0 +1,7 @@
+tools:
+- name: mothur_sub_sample
+  owner: iuc
+  revisions:
+  - e866e31f6da3
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
There are known issues with the version of this tool on GA.  Igor has tested the older version on Galaxy Europe and it works.