### PR TITLE
remove raxml from skip_tools list

### DIFF
--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -32,8 +32,6 @@ trusted_owners:
   - name: gemini_annotate
   - name: gemini_query
   - name: gemini_comp_hets
-  - name: raxml
-    revision: 73a469f7dc96
   - name: scanpy_inspect # test failures, CB to investigate
     revision: 6c145a6868cc
   - name: scanpy_plot # test failures, CB to investigate


### PR DESCRIPTION
Tool destinations has been updated to send jobs with very small inputs to slurm1 - we can see how it goes in tomorrow's update