### PR TITLE
Jenkins venv needs h5py for some tests

### DIFF
--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -2,5 +2,7 @@ pyyaml
 -e git+https://github.com/cat-bro/ephemeris.git@master#egg=ephemeris
 bioblend==0.13.0
 planemo==0.70.0
+
 # requirements for galaxy virtualenv also required here for tests to run correctly
 pysam==0.15.2
+h5py==2.10.0


### PR DESCRIPTION
h5py is imported in the galaxy-tool-util testing in the same way as pysam:

```
try:
    import h5py
except ImportError:
    h5py = None
```
