### PR TITLE
Update tool labels in panel

### DIFF
--- a/jenkins/report.sh
+++ b/jenkins/report.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
-SECRET_ENV_FILE=".secret.env"; # todo: run this script from within main.sh
+SECRET_ENV_FILE=".secret.env"; # todo: abstract this repeated block somehow
 [ -f $SECRET_ENV_FILE ] && LOCAL_ENV=1 || LOCAL_ENV=0
 [ $LOCAL_ENV = 0 ] && VENV_PATH="/var/lib/jenkins/jobs_common" || VENV_PATH=".."
 VIRTUALENV="$VENV_PATH/.venv3"
-# shellcheck source=../.venv/bin/activate
+# shellcheck source=$VIRTUALENV/bin/activate
 . "$VIRTUALENV/bin/activate"
 
 REPORT_DATE=$(env TZ="Australia/Queensland" date "+%Y-%m-%d")

--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -1,7 +1,10 @@
+arrow
 pyyaml
+pytz
 -e git+https://github.com/cat-bro/ephemeris.git@master#egg=ephemeris
 bioblend==0.13.0
 planemo==0.70.0
+galaxy-util==20.5.0
 
 # requirements for galaxy virtualenv also required here for tests to run correctly
 pysam==0.15.2

--- a/jenkins/update_tool_panel_labels.sh
+++ b/jenkins/update_tool_panel_labels.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+source .env
+
+SECRET_ENV_FILE=".secret.env"; # todo: abstract this repeated block somehow
+[ -f $SECRET_ENV_FILE ] && LOCAL_ENV=1 || LOCAL_ENV=0
+[ $LOCAL_ENV = 0 ] && VENV_PATH="/var/lib/jenkins/jobs_common" || VENV_PATH=".."
+VIRTUALENV="$VENV_PATH/.venv3"
+# shellcheck source=$VIRTUALENV/bin/activate
+. "$VIRTUALENV/bin/activate"
+
+DISPLAY_NEW_DAYS='14'
+DISPLAY_UPDATED_DAYS='14'
+REMOTE_USER='galaxy'
+FILE_PRODUCTION=/mnt/galaxy-app/config/shed_tool_conf.xml
+FILE_STAGING=/mnt/galaxy/galaxy-app/config/shed_tool_conf.xml
+
+python scripts/update_tool_panel_labels.py \
+  --display_new_days $DISPLAY_NEW_DAYS \
+  --display_updated_days $DISPLAY_UPDATED_DAYS \
+  --remote_user $REMOTE_USER \
+  --galaxy_url $STAGING_URL \
+  --remote_file_path $FILE_STAGING \
+  --safe
+
+python scripts/update_tool_panel_labels.py \
+  --display_new_days $DISPLAY_NEW_DAYS \
+  --display_updated_days $DISPLAY_UPDATED_DAYS \
+  --remote_user $REMOTE_USER \
+  --galaxy_url $PRODUCTION_URL \
+  --remote_file_path $FILE_PRODUCTION \
+  --safe
+

--- a/scripts/update_tool_panel_labels.py
+++ b/scripts/update_tool_panel_labels.py
@@ -1,0 +1,149 @@
+import argparse
+import os
+import arrow
+import yaml
+
+from galaxy.util.tool_shed.xml_util import parse_xml
+from galaxy.util import xml_to_string
+
+from utils import (
+    load_log,
+    get_remote_file,
+    copy_file_to_remote_location,
+    get_toolshed_tools,
+)
+
+from pytz import timezone
+
+"""
+Copy shed_tool_conf.xml from a remote galaxy instance and update each tool with labels.  The
+labels applied are from a yaml file stored in this repo, or 'new' and 'updated' labels for 
+tools that have recently been installed.  The script copies the file over, updates the labels
+in the xml and copies it back to where it started.  When running with the --safe argument
+the original file will not be overwritten and will be copied back to its directory under
+a new name to be reviewed by a human.
+"""
+
+date_format = 'DD/MM/YY HH:mm:ss'
+arrow_parsable_date_format = 'YYYY-MM-DD HH:mm:ss'
+aest = timezone('Australia/Queensland')
+
+tool_labels_file = 'tool_panel/tool_labels.yml'
+new_label = 'new'
+updated_label = 'updated'
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Update galaxy shed_tool_conf.xml with tool labels')
+    parser.add_argument('-g', '--galaxy_url', help='Galaxy server URL', required=True)
+    parser.add_argument('-u', '--remote_user', help='Remote user', default='galaxy')
+    parser.add_argument('-f', '--remote_file_path', help='File name on galaxy', required=True)
+    parser.add_argument('-k', '--key_path', help='Path to private ssh key file')  # for local testing - jenkins has the ssh identity already
+    parser.add_argument('--display_new_days', type=int, help='Number of days to display label for new tool', required=True)
+    parser.add_argument('--display_updated_days', type=int, help='Number of days to display label for updated tool', required=True)
+    parser.add_argument('--safe', action='store_true', help='Do not overwrite the original file, give the updated file a new name')
+    args = parser.parse_args()
+
+    file = os.path.basename(args.remote_file_path)
+    galaxy_url = args.galaxy_url
+    display_new_days = args.display_new_days
+    display_updated_days = args.display_updated_days
+
+    copy_args = {
+        'file': file,
+        'remote_user': args.remote_user,
+        'url': galaxy_url.split('//')[1] if galaxy_url.startswith('https://') else galaxy_url,
+        'remote_file_path': args.remote_file_path,
+        'key_path': args.key_path,
+    }
+
+    def filter_new(row):
+        return row['Status'] == 'Installed' and in_time_window(row['Date (AEST)'], display_new_days) and row['New Tool'] == 'True'
+
+    def filter_updated(row):
+        return row['Status'] == 'Installed' and in_time_window(row['Date (AEST)'], display_updated_days) and row['New Tool'] == 'False'
+
+    with open(tool_labels_file) as handle:
+        tool_labels = yaml.safe_load(handle)
+    
+    tool_labels.update({
+        new_label: [],
+        updated_label: [],
+    })
+
+    toolshed_tools = get_toolshed_tools(galaxy_url)
+
+    for row in load_log(filter=filter_new):
+        tool_ids = [t['id'] for t in toolshed_tools if (
+            t['tool_shed_repository']['name'] == row['Name']
+            and t['tool_shed_repository']['owner'] == row['Owner']
+            and t['tool_shed_repository']['changeset_revision'] == row['Installed Revision']
+        )]
+        tool_labels[new_label].extend(tool_ids)
+    
+    for row in load_log(filter=filter_updated):
+        tool_ids = [t['id'] for t in toolshed_tools if (
+            t['tool_shed_repository']['name'] == row['Name']
+            and t['tool_shed_repository']['owner'] == row['Owner']
+            and t['tool_shed_repository']['changeset_revision'] == row['Installed Revision']
+        )]
+        tool_labels[updated_label].extend(tool_ids)
+
+    try:
+        get_remote_file(**copy_args)
+    except Exception as e:
+        print(e)
+        raise Exception('Failed to fetch remote file')
+
+    tree, error_message = parse_xml(file)
+    root = tree.getroot()
+    # shed_tool_conf.xml has multiple section elements containing tools
+    # loop through all sections and tools
+    for section in root:
+        if section.tag == 'section':
+            for tool in section.getchildren():
+                if tool.tag == 'tool':
+                    tool_id = tool.find('id').text
+                    # remove all existing labels
+                    tool.attrib.pop('labels', None)
+                     # replace labels from dict
+                    labels_for_tool = []
+                    for label in tool_labels:
+                        for id in tool_labels[label]:
+                            if tool_id == id or (
+                                id.endswith('*') and get_deversioned_id(id) == get_deversioned_id(tool_id)
+                            ):
+                                labels_for_tool.append(label)
+                                break
+                    if labels_for_tool:
+                        tool.set('labels', ','.join(labels_for_tool))
+
+
+    with open(file, 'w') as handle:
+        handle.write(xml_to_string(root, pretty=True))
+    
+    if args.safe:
+        remote_file_path = copy_args['remote_file_path']
+        copy_args.update({
+            'remote_file_path': '%s_jenkins_%s' % (remote_file_path, arrow.now().format('YYYYMMDD'))
+        })
+
+    try:
+        copy_file_to_remote_location(**copy_args)
+    except Exception as e:
+        print(e)
+        raise Exception('Failed to copy file to remote instance')
+
+
+def get_deversioned_id(tool_id):
+    return '/'.join(tool_id.split('/')[:-1])
+
+
+def in_time_window(time_str, days):
+    # return True if time_str is less than a certain number of days ago
+    converted_datetime = arrow.get(time_str, date_format).format(arrow_parsable_date_format)
+    return arrow.get(converted_datetime, tzinfo=aest) > arrow.now().shift(days=-days)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,60 @@
+import csv
+import subprocess
+
+from bioblend.galaxy import GalaxyInstance
+from bioblend.toolshed import ToolShedInstance
+
+
+def get_galaxy_instance(url, api_key=None):
+    if not url.startswith('https://'):
+        url = 'https://' + url
+    return GalaxyInstance(url, api_key)
+
+def get_toolshed_instance(url):
+    if not url.startswith('https://'):
+        url = 'https://' + url
+    return ToolShedInstance(url=url)
+
+def get_repositories(url, api_key):
+    galaxy = get_galaxy_instance(url, api_key)
+    return galaxy.toolshed.get_repositories()
+
+
+def get_toolshed_tools(url, api_key=None):
+    galaxy = get_galaxy_instance(url, api_key)
+    return [tool for tool in galaxy.tools.get_tools() if tool.get('tool_shed_repository')]
+
+
+def load_log(filter=None):
+    """
+    Load the installation log tsv file and return it as a list row objects, i.e.
+    [{'Build Num.': '156', 'Name': 'abricate', ...}, {'Build Num.': '156', 'Name': 'bedtools', ...},...]
+    The filter argument is a function that takes a row as input and returns True or False
+    """
+    log_file = 'automated_tool_installation_log.tsv'
+    table = []
+    with open(log_file) as tsvfile:
+        reader = csv.DictReader(tsvfile, dialect='excel-tab')
+        for row in reader:
+            if not filter or filter(row):
+                table.append(row)
+    return table
+
+
+def get_valid_tools_for_repo(name, owner, revision, tool_shed_url):
+    toolshed = get_toolshed_instance(tool_shed_url)
+    data = toolshed.repositories.get_repository_revision_install_info(name, owner, revision)
+    repository, metadata, install_info = data
+    return metadata.get('valid_tools')
+
+
+def get_remote_file(file, remote_file_path, url, remote_user, key_path=None):
+    key_arg = '' if not key_path else '-i %s' % key_path
+    command = 'scp %s %s@%s:%s %s' % (key_arg, remote_user, url, remote_file_path, file)
+    subprocess.check_output(command, shell=True)
+
+
+def copy_file_to_remote_location(file, remote_file_path, remote_user, url, key_path=None):
+    key_arg = '' if not key_path else '-i %s' % key_path
+    command = 'scp %s %s %s@%s:%s' % (key_arg, file, remote_user, url, remote_file_path)
+    subprocess.check_output(command, shell=True)

--- a/tool_panel/tool_labels.yml
+++ b/tool_panel/tool_labels.yml
@@ -1,0 +1,13 @@
+deprecated:
+- toolshed.g2.bx.psu.edu/repos/devteam/tophat2/tophat2/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cuffquant/cuffquant/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cuffnorm/cuffnorm/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cuffmerge/cuffmerge/*
+- toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/*
+training-only:
+- toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvet/*
+- toolshed.g2.bx.psu.edu/repos/devteam/velvet/velvetg/*
+- toolshed.g2.bx.psu.edu/repos/devteam/velvet/velveth/*
+- toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/*


### PR DESCRIPTION
Jenkins script to copy shed_tool_conf.xml and label tools as 'new' or 'updated' if they have been installed in the past 14 days.  Other tool labels are defined in tool_panel/tool_labels.yml (deprecated, training-only).

This uses methods from galaxy-util for parsing and writing xml, so comments are preserved and the resulting file is like the original but for the labels.

The labels have been added to the tool panel on staging.