### PR TITLE
[FORCE] fasta_merge_files_and_filter_unique_sequences, velvet

### DIFF
--- a/requests/fasta_merge_files_and_filter_unique_sequences@650d553c1fda.yml
+++ b/requests/fasta_merge_files_and_filter_unique_sequences@650d553c1fda.yml
@@ -1,0 +1,7 @@
+tools:
+- name: fasta_merge_files_and_filter_unique_sequences
+  owner: galaxyp
+  revisions:
+  - 650d553c1fda
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/velvet@8d09f8be269e.yml
+++ b/requests/velvet@8d09f8be269e.yml
@@ -1,0 +1,7 @@
+tools:
+- name: velvet
+  owner: devteam
+  revisions:
+  - 8d09f8be269e
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
- fasta_merge_files_and_filter_unique_sequences fails its test because of a newline at the end of the output file
- velvet fails output diffs on production but this can pass because is is a training-only tool
