### PR TITLE
data manager for bwameth

### DIFF
--- a/requests/data_manager_bwameth_index_builder.yml
+++ b/requests/data_manager_bwameth_index_builder.yml
@@ -1,0 +1,4 @@
+tools:
+  - name: data_manager_bwameth_index_builder
+    owner: iuc
+    tool_panel_section_label: None


### PR DESCRIPTION
Tools were recently added for Epigenetics tutorials.  One of the tutorials cannot be run yet because there is no reference data for bwameth