### PR TITLE
try installing 2d_split_binaryimage_by_watershed again

### DIFF
--- a/requests/2d_split_binaryimage_by_watershed.yml
+++ b/requests/2d_split_binaryimage_by_watershed.yml
@@ -1,0 +1,6 @@
+tools:
+- name: 2d_split_binaryimage_by_watershed
+  owner: imgteam
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+


### PR DESCRIPTION
One of the imaging tools failed to install properly then apparently failed to uninstall properly.