### PR TITLE
galaxy-wait before winding back installation

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -406,6 +406,8 @@ update_tool_list() {
   rm -f $TMP_TOOL_FILE ||:; # remove temp file if it exists
   [ -d $TOOL_DIR ] || mkdir $TOOL_DIR;  # make directory if it does not exist
   rm $TOOL_DIR/*; # Delete tool files to replace them with split_tool_yml output
+  echo "Waiting for $URL";
+  galaxy-wait -g $URL
   get-tool-list -g $URL -a $API_KEY -o $TMP_TOOL_FILE --get_all_tools
   python scripts/split_tool_yml.py -i $TMP_TOOL_FILE -o $TOOL_DIR; # Simon's script
   rm $TMP_TOOL_FILE

--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -358,10 +358,14 @@ uninstall_tool() {
   if [ $VERSION_UPDATE = 1 ]; then
     echo "This tool cannot be uninstalled as the version is already installed."
   else
-    echo "Uninstalling on $URL";
+    echo "Waiting for $URL"
+    galaxy-wait -g $URL
+    echo "Uninstalling on $URL"
     python scripts/uninstall_tools.py -g $URL -a $API_KEY -n "$INSTALLED_NAME@$INSTALLED_REVISION";
     if [ $SERVER = "PRODUCTION" ]; then
       # also uninstall on staging
+      echo "Waiting for $STAGING_URL"
+      galaxy-wait -g $STAGING_URL
       echo "Uninstalling on $STAGING_URL";
       python scripts/uninstall_tools.py -g $STAGING_URL -a $STAGING_API_KEY -n "$INSTALLED_NAME@$INSTALLED_REVISION";
     fi


### PR DESCRIPTION
Some of the uninstall requests fail because Galaxy is under heavy load.  This may help.