### PR TITLE
Jenkins install build 475 (amended)

### DIFF
--- a/galaxy-aust-staging/annotation.yml
+++ b/galaxy-aust-staging/annotation.yml
@@ -2,17 +2,17 @@ tools:
 - name: abricate
   owner: iuc
   revisions:
-  - 6e9aea89e388
   - 4efdca267d51
-  - 78c75f134c16
   - b734db305578
+  - 6e9aea89e388
+  - 78c75f134c16
   tool_panel_section_label: Annotation
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: annotatemyids
   owner: iuc
   revisions:
-  - b5d8e5475247
   - 1aae04680c4b
+  - b5d8e5475247
   tool_panel_section_label: Annotation
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: augustus_training
@@ -105,9 +105,9 @@ tools:
 - name: snpeff
   owner: iuc
   revisions:
-  - 74aebe30fb52
   - 268d162b9c49
   - 68693743661e
+  - 74aebe30fb52
   - 5a29ab10dba6
   tool_panel_section_label: Annotation
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/assembly.yml
+++ b/galaxy-aust-staging/assembly.yml
@@ -8,10 +8,10 @@ tools:
 - name: busco
   owner: iuc
   revisions:
+  - 4048d82f0c88
+  - 5ecdeca79a0d
   - 1e62c28ba91d
   - 382a4c19007f
-  - 5ecdeca79a0d
-  - 4048d82f0c88
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: canu
@@ -36,8 +36,8 @@ tools:
 - name: megahit
   owner: iuc
   revisions:
-  - de387b2b2803
   - 7518ee87b53d
+  - de387b2b2803
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: metaspades
@@ -61,25 +61,25 @@ tools:
 - name: quast
   owner: iuc
   revisions:
-  - ebb0dcdb621a
   - 6fcbee531de6
+  - ebb0dcdb621a
   - f30d03867854
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: racon
   owner: bgruening
   revisions:
-  - a199cd7ac344
   - aa39b19ca11e
+  - a199cd7ac344
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: shovill
   owner: iuc
   revisions:
   - d9f6a00b6db7
-  - 865119fcb694
   - 196a599ec43d
   - 57d5928f456e
+  - 865119fcb694
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: spades
@@ -92,8 +92,8 @@ tools:
 - name: unicycler
   owner: iuc
   revisions:
-  - 0a3a602cd1e3
   - 88c240872a65
+  - 0a3a602cd1e3
   - e92675014ac9
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
@@ -101,8 +101,8 @@ tools:
   owner: devteam
   revisions:
   - 08256557922f
-  - 8d09f8be269e
   - 5da9a0e2fb2d
+  - 8d09f8be269e
   tool_panel_section_label: Assembly
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: velvetoptimiser

--- a/galaxy-aust-staging/bacterial_typing.yml
+++ b/galaxy-aust-staging/bacterial_typing.yml
@@ -3,14 +3,14 @@ tools:
   owner: iuc
   revisions:
   - 8e8dc9a1e3e5
-  - 1f5641a52664
   - ded48b36f3b7
+  - 1f5641a52664
   tool_panel_section_label: Bacterial Typing
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sistr_cmd
   owner: nml
   revisions:
-  - 5c8ff92e38a9
   - 17fcac7ddf54
+  - 5c8ff92e38a9
   tool_panel_section_label: Bacterial Typing
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/bed.yml
+++ b/galaxy-aust-staging/bed.yml
@@ -2,10 +2,10 @@ tools:
 - name: bedtools
   owner: iuc
   revisions:
-  - 87ee588b3d45
+  - b28e0cfa7ba1
   - a8eabd2838f6
   - 0a5c785ac6db
   - e19bebe96cd2
-  - b28e0cfa7ba1
+  - 87ee588b3d45
   tool_panel_section_label: BED
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/blast.yml
+++ b/galaxy-aust-staging/blast.yml
@@ -8,9 +8,9 @@ tools:
 - name: ncbi_blast_plus
   owner: devteam
   revisions:
+  - 2889433c7ae1
   - e25d3acf6e68
   - 6f386c5dc4fb
-  - 2889433c7ae1
   tool_panel_section_label: Blast +
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: taxonomy_krona_chart

--- a/galaxy-aust-staging/chemicaltoolbox.yml
+++ b/galaxy-aust-staging/chemicaltoolbox.yml
@@ -32,8 +32,8 @@ tools:
 - name: ctb_frankenstein_ligand
   owner: bgruening
   revisions:
-  - 8e214e52e461
   - 7255688c77f3
+  - 8e214e52e461
   tool_panel_section_label: ChemicalToolBox
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: enumerate_charges
@@ -71,8 +71,8 @@ tools:
 - name: gmx_setup
   owner: chemteam
   revisions:
-  - ccdf0b30a422
   - 4da9ee404eab
+  - ccdf0b30a422
   tool_panel_section_label: ChemicalToolBox
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gmx_sim
@@ -97,9 +97,9 @@ tools:
 - name: openbabel_compound_convert
   owner: bgruening
   revisions:
-  - 1c66bf08f687
   - b59c91adeac1
   - e6011617c748
+  - 1c66bf08f687
   tool_panel_section_label: ChemicalToolBox
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: rdock_rbcavity
@@ -112,17 +112,17 @@ tools:
 - name: rdock_rbdock
   owner: bgruening
   revisions:
+  - c362398df83b
   - a22969b08177
   - e4b7d1507a75
-  - c362398df83b
   tool_panel_section_label: ChemicalToolBox
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sucos_max_score
   owner: bgruening
   revisions:
-  - 85fad59f8168
   - 55ac04db36aa
-  - bf99565cec1f
+  - 85fad59f8168
   - d4c67ced6abc
+  - bf99565cec1f
   tool_panel_section_label: ChemicalToolBox
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/chip_seq.yml
+++ b/galaxy-aust-staging/chip_seq.yml
@@ -28,23 +28,23 @@ tools:
 - name: macs21
   owner: pjbriggs
   revisions:
-  - 11cf21ee4242
   - 4124781932db
+  - 11cf21ee4242
   tool_panel_section_label: ChiP-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: macs2
   owner: iuc
   revisions:
   - 495a4173006f
-  - 424aefbd7777
   - f5d67c722d67
+  - 424aefbd7777
   tool_panel_section_label: ChiP-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: rnachipintegrator
   owner: pjbriggs
   revisions:
-  - b695071de766
   - 087d9872fb0d
+  - b695071de766
   tool_panel_section_label: ChiP-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sicer

--- a/galaxy-aust-staging/collection_operations.yml
+++ b/galaxy-aust-staging/collection_operations.yml
@@ -2,17 +2,17 @@ tools:
 - name: bundle_collections
   owner: nml
   revisions:
-  - cd6da887a5f4
   - 705ebd286b57
+  - cd6da887a5f4
   tool_panel_section_label: Collection Operations
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: collapse_collections
   owner: nml
   revisions:
-  - 25136a2b0cfe
-  - 33151a38533a
-  - 90981f86000f
   - 830961c48e42
+  - 90981f86000f
+  - 33151a38533a
+  - 25136a2b0cfe
   tool_panel_section_label: Collection Operations
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: collection_column_join
@@ -25,8 +25,8 @@ tools:
 - name: split_file_to_collection
   owner: bgruening
   revisions:
-  - 6cbe2f30c2d7
   - d57735dd27b0
+  - 6cbe2f30c2d7
   tool_panel_section_label: Collection Operations
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: unzip

--- a/galaxy-aust-staging/convert_formats.yml
+++ b/galaxy-aust-staging/convert_formats.yml
@@ -21,29 +21,29 @@ tools:
 - name: biom_convert
   owner: iuc
   revisions:
-  - 501c21cce614
   - 584008e574b2
+  - 501c21cce614
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bp_genbank2gff3
   owner: iuc
   revisions:
-  - 11c3eb512633
   - a0d092f27fdf
+  - 11c3eb512633
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_to_tabular
   owner: devteam
   revisions:
-  - e7ed3c310b74
   - 7e801ab2b70e
+  - e7ed3c310b74
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_to_fasta
   owner: devteam
   revisions:
-  - 186b8d913e6c
   - e282bc27be9a
+  - 186b8d913e6c
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_to_tabular
@@ -93,14 +93,14 @@ tools:
 - name: tabular_to_fastq
   owner: devteam
   revisions:
-  - 2dcfbbf9071a
   - b8cdc0507586
+  - 2dcfbbf9071a
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: thermo_raw_file_converter
   owner: galaxyp
   revisions:
-  - 26c6706bfb07
   - 63769c4217a7
+  - 26c6706bfb07
   tool_panel_section_label: Convert Formats
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/deeptools.yml
+++ b/galaxy-aust-staging/deeptools.yml
@@ -2,17 +2,17 @@ tools:
 - name: deeptools_bam_compare
   owner: bgruening
   revisions:
-  - e821645ef8fc
-  - c09c23eaf116
   - a1ca9bccc7f2
+  - c09c23eaf116
+  - e821645ef8fc
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_bam_coverage
   owner: bgruening
   revisions:
-  - 5d11599b8a7d
   - fe7cc56090ea
   - bb1e4f63e0e6
+  - 5d11599b8a7d
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_bam_pe_fragmentsize
@@ -25,97 +25,97 @@ tools:
 - name: deeptools_bigwig_compare
   owner: bgruening
   revisions:
-  - 9c346a32a053
   - 26e7304d6737
+  - 9c346a32a053
   - bfff7454b59a
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_compute_gc_bias
   owner: bgruening
   revisions:
+  - fe8eeeeb9a4a
   - 29fcfd36e90a
   - 2bc10a9ca58b
-  - fe8eeeeb9a4a
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_compute_matrix_operations
   owner: bgruening
   revisions:
-  - 72bfafe3330b
   - ee3a1b0f45f1
   - f98fc5acd9f7
+  - 72bfafe3330b
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_compute_matrix
   owner: bgruening
   revisions:
+  - f305afa8ff0d
   - fd1275e01605
   - 514fa53b5efb
-  - f305afa8ff0d
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_correct_gc_bias
   owner: bgruening
   revisions:
   - 2c37ce318bc3
-  - 806f79d7de8d
   - a02cfa31e9cb
+  - 806f79d7de8d
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_multi_bam_summary
   owner: bgruening
   revisions:
-  - 78f405266706
-  - 2d466b530754
   - 894c933a2677
+  - 2d466b530754
+  - 78f405266706
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_multi_bigwig_summary
   owner: bgruening
   revisions:
-  - 3c9f0c486cca
   - 676c37fbac81
+  - 3c9f0c486cca
   - db940c262830
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_correlation
   owner: bgruening
   revisions:
+  - 1d292ed31178
   - 32e451def88c
   - f264afa9fa6f
-  - 1d292ed31178
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_coverage
   owner: bgruening
   revisions:
-  - 7e361d147872
   - 56bce3c82278
+  - 7e361d147872
   - 017710636d31
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_enrichment
   owner: bgruening
   revisions:
-  - e65d16fb2724
   - '118919005989'
+  - e65d16fb2724
   - 94ca68515826
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_fingerprint
   owner: bgruening
   revisions:
+  - f8fc4e5aff9d
   - 2da482e408b8
   - ff8cb4fd1b9a
-  - f8fc4e5aff9d
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_heatmap
   owner: bgruening
   revisions:
+  - 59067d653c9b
   - a4dfb122e52b
   - 512155688d98
-  - 59067d653c9b
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deeptools_plot_pca
@@ -129,8 +129,8 @@ tools:
 - name: deeptools_plot_profile
   owner: bgruening
   revisions:
-  - aac8444d6681
-  - 1d290f98916a
   - c361b12d207a
+  - 1d290f98916a
+  - aac8444d6681
   tool_panel_section_label: DeepTools
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/fastafastq.yml
+++ b/galaxy-aust-staging/fastafastq.yml
@@ -22,8 +22,8 @@ tools:
 - name: fasta_compute_length
   owner: devteam
   revisions:
-  - de2db1bdfbf8
   - 7d37cfda8e00
+  - de2db1bdfbf8
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_concatenate_by_species
@@ -42,29 +42,29 @@ tools:
 - name: fasta_filter_by_length
   owner: devteam
   revisions:
-  - 2fd6033d0e9c
   - 8cacfcf96a52
+  - 2fd6033d0e9c
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_formatter
   owner: devteam
   revisions:
-  - 9457a20156db
   - 859422bcb689
+  - 9457a20156db
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_merge_files_and_filter_unique_sequences
   owner: galaxyp
   revisions:
-  - 2904d46167da
   - 650d553c1fda
+  - 2904d46167da
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_nucleotide_changer
   owner: devteam
   revisions:
-  - ec0b5076173a
   - f81d4362b6c1
+  - ec0b5076173a
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fasta_stats
@@ -89,8 +89,8 @@ tools:
 - name: fastq_combiner
   owner: devteam
   revisions:
-  - 56389130cb63
   - f1dc2a761c30
+  - 56389130cb63
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_filter
@@ -103,8 +103,8 @@ tools:
 - name: fastq_groomer
   owner: devteam
   revisions:
-  - 47e5dbc3e790
   - 71e5fa25b8a2
+  - 47e5dbc3e790
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_manipulation
@@ -117,8 +117,8 @@ tools:
 - name: fastq_masker_by_quality
   owner: devteam
   revisions:
-  - 9dfda4e310ed
   - eb592e9ec47a
+  - 9dfda4e310ed
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_paired_end_deinterlacer
@@ -152,23 +152,23 @@ tools:
 - name: fastq_quality_converter
   owner: devteam
   revisions:
-  - 54053ea6c77e
   - 74db4cffab1f
+  - 54053ea6c77e
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_quality_filter
   owner: devteam
   revisions:
-  - e41385662e5e
-  - 7b4468117008
   - ce9cd02d5b88
+  - 7b4468117008
+  - e41385662e5e
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_stats
   owner: devteam
   revisions:
-  - e2cf940128d5
   - f0e7deab6518
+  - e2cf940128d5
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_trimmer
@@ -181,23 +181,23 @@ tools:
 - name: fastx_artifacts_filter
   owner: devteam
   revisions:
-  - 567d5b3c52b1
   - 09070cacefd8
+  - 567d5b3c52b1
   - d5e9e83cd3d8
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastx_barcode_splitter
   owner: devteam
   revisions:
-  - 4bedca26c133
   - 8abdedf55101
+  - 4bedca26c133
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastx_clipper
   owner: devteam
   revisions:
-  - b8658f852bc7
   - 736b8f6ee456
+  - b8658f852bc7
   - bdf1ce174e39
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
@@ -218,15 +218,15 @@ tools:
 - name: fastx_quality_statistics
   owner: devteam
   revisions:
-  - 7306ec78632a
   - 59003d0543cd
+  - 7306ec78632a
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastx_renamer
   owner: devteam
   revisions:
-  - b29d37ca9e41
   - 02f8a17a4ebd
+  - b29d37ca9e41
   - 3599f5451ee2
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
@@ -287,14 +287,14 @@ tools:
 - name: umi_tools_count
   owner: iuc
   revisions:
-  - 276b4111b253
   - b557acca0b56
+  - 276b4111b253
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: umi_tools_extract
   owner: iuc
   revisions:
-  - d5ff68d2d5ff
   - 828dba98cdb4
+  - d5ff68d2d5ff
   tool_panel_section_label: FASTA/FASTQ
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/fastq_quality_control.yml
+++ b/galaxy-aust-staging/fastq_quality_control.yml
@@ -74,8 +74,8 @@ tools:
 - name: fastq_trimmer_by_quality
   owner: devteam
   revisions:
-  - 8050e091e99b
   - c64d534a763c
+  - 8050e091e99b
   tool_panel_section_label: FASTQ Quality Control
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastq_trimmer_by_quality
@@ -93,11 +93,11 @@ tools:
 - name: fastqc
   owner: devteam
   revisions:
+  - c15237684a01
   - ff9530579d1f
+  - f2e8552cf1d0
   - 2b0c9d9fc6ca
   - e7b2202befea
-  - c15237684a01
-  - f2e8552cf1d0
   tool_panel_section_label: FASTQ Quality Control
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: fastqc
@@ -121,10 +121,10 @@ tools:
 - name: multiqc
   owner: iuc
   revisions:
-  - 3d93dd18d9f8
-  - bf675f34b056
-  - 1c2db0054039
   - b2f1f75d49c4
+  - bf675f34b056
+  - 3d93dd18d9f8
+  - 1c2db0054039
   tool_panel_section_label: FASTQ Quality Control
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ngsutils_bam_filter
@@ -136,8 +136,8 @@ tools:
 - name: trim_galore
   owner: bgruening
   revisions:
-  - 084bbd8ba7b8
   - 949f01671246
+  - 084bbd8ba7b8
   tool_panel_section_label: FASTQ Quality Control
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: trim_galore

--- a/galaxy-aust-staging/gemini_tools.yml
+++ b/galaxy-aust-staging/gemini_tools.yml
@@ -2,44 +2,44 @@ tools:
 - name: gemini_actionable_mutations
   owner: iuc
   revisions:
-  - 142d95ab942e
   - 3630a6e624d4
+  - 142d95ab942e
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_amend
   owner: iuc
   revisions:
-  - 4bd4870ecd33
   - be828b79bd4d
+  - 4bd4870ecd33
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_annotate
   owner: iuc
   revisions:
-  - f2f3bc622a16
-  - 8f53b238a360
   - 0c8f7322f8fc
+  - 8f53b238a360
+  - f2f3bc622a16
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_burden
   owner: iuc
   revisions:
-  - df57188562f0
   - 1a4c5adcd587
+  - df57188562f0
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_comp_hets
   owner: iuc
   revisions:
-  - 7cf9bc210044
   - 62647e2637f6
+  - 7cf9bc210044
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_db_info
   owner: iuc
   revisions:
-  - 7d75673f4d6f
   - 4c5f4e9b1931
+  - 7d75673f4d6f
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_de_novo
@@ -52,8 +52,8 @@ tools:
 - name: gemini_dump
   owner: iuc
   revisions:
-  - 40f85b45e472
   - 96a2d270bf0f
+  - 40f85b45e472
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_fusions
@@ -86,23 +86,23 @@ tools:
 - name: gemini_load
   owner: iuc
   revisions:
-  - b2c25142267e
   - cf61daf064fe
+  - b2c25142267e
   - 45296e47d565
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_lof_sieve
   owner: iuc
   revisions:
-  - 90021fffff70
   - 2969a1f43b7d
+  - 90021fffff70
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_mendel_errors
   owner: iuc
   revisions:
-  - 61343646155c
   - 00c2734b3bea
+  - 61343646155c
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_pathways
@@ -115,23 +115,23 @@ tools:
 - name: gemini_qc
   owner: iuc
   revisions:
-  - 9e83673fa6d2
   - 86e46972e183
+  - 9e83673fa6d2
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_query
   owner: iuc
   revisions:
-  - da74170c55c7
-  - 666f60a9331a
   - 840fb4850be3
+  - 666f60a9331a
+  - da74170c55c7
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_recessive_and_dominant
   owner: iuc
   revisions:
-  - 86f3aac4418d
   - 05124dc72dba
+  - 86f3aac4418d
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_region
@@ -151,15 +151,15 @@ tools:
 - name: gemini_set_somatic
   owner: iuc
   revisions:
-  - e4e2128460e3
   - ef9991a4a9a7
+  - e4e2128460e3
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_stats
   owner: iuc
   revisions:
-  - 5c9efee9cb1e
   - ee894347fcd6
+  - 5c9efee9cb1e
   tool_panel_section_label: Gemini Tools
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: gemini_windower

--- a/galaxy-aust-staging/genome_editing.yml
+++ b/galaxy-aust-staging/genome_editing.yml
@@ -16,8 +16,8 @@ tools:
 - name: mageck_mle
   owner: iuc
   revisions:
-  - b36c85e37a48
   - 26126538a86f
+  - b36c85e37a48
   tool_panel_section_label: Genome Editing
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: mageck_pathway
@@ -30,7 +30,7 @@ tools:
 - name: mageck_test
   owner: iuc
   revisions:
-  - 9b4f4533c9ee
   - 688a8eccea71
+  - 9b4f4533c9ee
   tool_panel_section_label: Genome Editing
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/get_data.yml
+++ b/galaxy-aust-staging/get_data.yml
@@ -2,8 +2,8 @@ tools:
 - name: dbbuilder
   owner: galaxyp
   revisions:
-  - b39347891609
   - c1b437242fee
+  - b39347891609
   tool_panel_section_label: Get Data
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ncbi_acc_download
@@ -15,12 +15,12 @@ tools:
 - name: sra_tools
   owner: iuc
   revisions:
-  - 8c00bc7fd8de
   - c441583adae5
-  - 7068f48d0ef9
-  - 653e89d73fc4
+  - 8c00bc7fd8de
   - aad3885b3216
-  - f5ea3ce9b9b0
+  - 7068f48d0ef9
   - 1790dcf3c32d
+  - 653e89d73fc4
+  - f5ea3ce9b9b0
   tool_panel_section_label: Get Data
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/graphdisplay_data.yml
+++ b/galaxy-aust-staging/graphdisplay_data.yml
@@ -3,11 +3,11 @@ tools:
   owner: iuc
   revisions:
   - e6cbe3190642
-  - a64dc31ab7f2
-  - 4b519282a05b
-  - 740057a5126d
   - ef5f8bbf7730
   - fd59d783248a
+  - 740057a5126d
+  - 4b519282a05b
+  - a64dc31ab7f2
   tool_panel_section_label: Graph/Display Data
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: draw_stacked_barplots
@@ -25,8 +25,8 @@ tools:
 - name: fastq_quality_boxplot
   owner: devteam
   revisions:
-  - f95284aa2946
   - 7cf5b1d072b5
+  - f95284aa2946
   tool_panel_section_label: Graph/Display Data
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ggplot2_heatmap2
@@ -80,12 +80,12 @@ tools:
 - name: jbrowse
   owner: iuc
   revisions:
-  - fd5dbf0f732e
   - d0743cb18ed8
-  - 1cfc579079a6
-  - 836d1aa3e89a
-  - 17359b808b01
   - 667e17248bfe
+  - 836d1aa3e89a
+  - 1cfc579079a6
+  - fd5dbf0f732e
+  - 17359b808b01
   tool_panel_section_label: Graph/Display Data
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: krona_text
@@ -115,8 +115,8 @@ tools:
 - name: plotly_ml_performance_plots
   owner: bgruening
   revisions:
-  - 62e3a4e8c54c
   - 85da91bbdbfb
+  - 62e3a4e8c54c
   tool_panel_section_label: Graph/Display Data
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: plotly_parallel_coordinates_plot

--- a/galaxy-aust-staging/ivar.yml
+++ b/galaxy-aust-staging/ivar.yml
@@ -2,55 +2,55 @@ tools:
 - name: ivar_consensus
   owner: iuc
   revisions:
-  - d6e72da3ec35
-  - f362150bef41
   - a38934e303b9
+  - f362150bef41
   - 78bbd17d0703
+  - d6e72da3ec35
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ivar_filtervariants
   owner: iuc
   revisions:
-  - 2b95d5c04908
-  - c88553ec696e
   - 7fe36019c073
   - f91cfb73d369
+  - c88553ec696e
+  - 2b95d5c04908
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ivar_getmasked
   owner: iuc
   revisions:
-  - 2cf4a1cafc16
   - d7e79eb3bcb3
   - ad0dc9f4c9e2
+  - 2cf4a1cafc16
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ivar_removereads
   owner: iuc
   revisions:
-  - 94df24c6bc00
-  - bd2a7d1316b9
-  - 3d18f8c3c0f6
-  - ee2beb764a7b
   - 9eaadf03e0df
+  - bd2a7d1316b9
+  - ee2beb764a7b
+  - 3d18f8c3c0f6
+  - 94df24c6bc00
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ivar_trim
   owner: iuc
   revisions:
-  - db536ad45f28
+  - 8858fa037a15
+  - cb903c9dc33d
   - 5d6ed46cc101
   - d37ede8589b2
-  - cb903c9dc33d
-  - 8858fa037a15
+  - db536ad45f28
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: ivar_variants
   owner: iuc
   revisions:
   - e1a015876aa9
-  - c5c9f02b6167
   - f95f403841ad
   - 12d66d0d05ac
+  - c5c9f02b6167
   tool_panel_section_label: iVar
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/machine_learning.yml
+++ b/galaxy-aust-staging/machine_learning.yml
@@ -23,7 +23,7 @@ tools:
 - name: sklearn_svm_classifier
   owner: bgruening
   revisions:
-  - f9639b488779
   - d2afc87db26b
+  - f9639b488779
   tool_panel_section_label: Machine Learning
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/mapping.yml
+++ b/galaxy-aust-staging/mapping.yml
@@ -3,16 +3,16 @@ tools:
   owner: devteam
   revisions:
   - 17062a0decb7
-  - 937aa69e715f
-  - dc1639b66f12
   - 749c918495f7
+  - dc1639b66f12
+  - 937aa69e715f
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bwa
   owner: devteam
   revisions:
-  - 53646aaaafef
   - 3fe632431b68
+  - 53646aaaafef
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lastz_paired_reads
@@ -31,24 +31,24 @@ tools:
 - name: minimap2
   owner: iuc
   revisions:
-  - b3eab4b67562
   - 53c0b7a1a0c3
+  - b3eab4b67562
   - 8c6cd2650d1f
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: rgrnastar
   owner: iuc
   revisions:
-  - 5ec75f5dae3c
+  - b9e04854e2bb
   - 2055c2667eb3
   - 99b17b74a8cd
-  - b9e04854e2bb
+  - 5ec75f5dae3c
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: rna_starsolo
   owner: iuc
   revisions:
-  - 178bdbdb6d24
   - e403d27e8f24
+  - 178bdbdb6d24
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/metabolomics.yml
+++ b/galaxy-aust-staging/metabolomics.yml
@@ -8,15 +8,15 @@ tools:
 - name: camera_annotate
   owner: lecorguille
   revisions:
-  - 6139bfcc95cb
   - 73d82de36369
+  - 6139bfcc95cb
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: camera_combinexsannos
   owner: mmonsoor
   revisions:
-  - 961089e21ae2
   - 479a83f62863
+  - 961089e21ae2
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: checkformat
@@ -35,23 +35,23 @@ tools:
 - name: golm_ws_lib_search
   owner: fgiacomoni
   revisions:
-  - 28d579fa1718
   - 11779b6402bc
+  - 28d579fa1718
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: hmdb_ms_search
   owner: fgiacomoni
   revisions:
-  - 49f87ddb2c78
   - 63ba1cb240b7
+  - 49f87ddb2c78
   - 4eb2de7c24d1
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lcmsmatching
   owner: prog
   revisions:
-  - f86fec07f392
   - fb9c0409d85c
+  - f86fec07f392
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lipidmaps_textsearch
@@ -93,16 +93,16 @@ tools:
 - name: nmr_preprocessing
   owner: marie-tremblay-metatoul
   revisions:
+  - 68e2d63bece0
   - cbea5e9fd0b4
   - 5b06800f3449
-  - 68e2d63bece0
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: normalization
   owner: marie-tremblay-metatoul
   revisions:
-  - f9554d5bb47e
   - 3d00a98974b7
+  - f9554d5bb47e
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: probmetab
@@ -202,14 +202,14 @@ tools:
 - name: xcms_summary
   owner: lecorguille
   revisions:
-  - acc0a4a366c1
   - 4c757d1ba7b4
+  - acc0a4a366c1
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: xcms_xcmsset
   owner: lecorguille
   revisions:
-  - 363cce459fff
   - 3bd53dcfa438
+  - 363cce459fff
   tool_panel_section_label: Metabolomics
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/metagenomic_analysis.yml
+++ b/galaxy-aust-staging/metagenomic_analysis.yml
@@ -27,8 +27,8 @@ tools:
 - name: fasttree
   owner: iuc
   revisions:
-  - c7e73acfa3eb
   - e005e659ae21
+  - c7e73acfa3eb
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: humann2_genefamilies_genus_level
@@ -76,17 +76,17 @@ tools:
 - name: kraken_filter
   owner: devteam
   revisions:
-  - 5bee9adae474
   - fe94f318048c
+  - 5bee9adae474
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: kraken_report
   owner: devteam
   revisions:
-  - a3a7440fc618
-  - 1902d3de4a4f
   - 6c09bed3444f
+  - a3a7440fc618
   - 9ae975c30dde
+  - 1902d3de4a4f
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: kraken_translate
@@ -100,8 +100,8 @@ tools:
   owner: devteam
   revisions:
   - 8ba2174315aa
-  - aec58624706f
   - 2fdac3e78553
+  - aec58624706f
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: maxbin2
@@ -233,8 +233,8 @@ tools:
 - name: staramr
   owner: nml
   revisions:
-  - aeaa20b96ef2
   - 2fd4d4c9c5c2
+  - aeaa20b96ef2
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: usearch_cluster_otus
@@ -264,7 +264,7 @@ tools:
 - name: vsearch
   owner: iuc
   revisions:
-  - 576963db5f1b
   - b3c7199d8786
+  - 576963db5f1b
   tool_panel_section_label: Metagenomic Analysis
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/mothur.yml
+++ b/galaxy-aust-staging/mothur.yml
@@ -704,8 +704,8 @@ tools:
 - name: mothur_sub_sample
   owner: iuc
   revisions:
-  - 0f4dfa0332e8
   - e866e31f6da3
+  - 0f4dfa0332e8
   tool_panel_section_label: Mothur
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: mothur_summary_qual

--- a/galaxy-aust-staging/nanopore.yml
+++ b/galaxy-aust-staging/nanopore.yml
@@ -20,29 +20,29 @@ tools:
 - name: nanoplot
   owner: iuc
   revisions:
-  - edbb6c5028f5
   - 645159bcee2d
+  - edbb6c5028f5
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: nanopolish_eventalign
   owner: bgruening
   revisions:
-  - 8fdb079ddaf0
   - d219b6d8158a
+  - 8fdb079ddaf0
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: nanopolish_methylation
   owner: bgruening
   revisions:
-  - 12efe2f03697
   - a8d4be409446
+  - 12efe2f03697
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: nanopolish_polya
   owner: bgruening
   revisions:
-  - 449e9aeded2d
   - be717b65851f
+  - 449e9aeded2d
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: nanopolish_variants
@@ -61,8 +61,8 @@ tools:
 - name: poretools_events
   owner: iuc
   revisions:
-  - 28d7819c312f
   - 1d835c691480
+  - 28d7819c312f
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: poretools_extract
@@ -74,8 +74,8 @@ tools:
 - name: poretools_hist
   owner: iuc
   revisions:
-  - 5a82eb9e1b89
   - 47936349f3e9
+  - 5a82eb9e1b89
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: poretools_nucdist
@@ -107,8 +107,8 @@ tools:
 - name: poretools_squiggle
   owner: iuc
   revisions:
-  - 34553d0caa5e
   - ce8af9373061
+  - 34553d0caa5e
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: poretools_stats
@@ -138,7 +138,7 @@ tools:
 - name: poretools_yield_plot
   owner: iuc
   revisions:
-  - 64a83664b814
   - ca22d8497db5
+  - 64a83664b814
   tool_panel_section_label: Nanopore
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/none.yml
+++ b/galaxy-aust-staging/none.yml
@@ -38,8 +38,8 @@ tools:
 - name: data_manager_bowtie2_index_builder
   owner: devteam
   revisions:
-  - 1c0f8e9d87c6
   - 83da94c0e4a6
+  - 1c0f8e9d87c6
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_build_kraken2_database
@@ -51,8 +51,8 @@ tools:
 - name: data_manager_bwa_mem_index_builder
   owner: devteam
   revisions:
-  - 37580590ecfb
   - 46066df8813d
+  - 37580590ecfb
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_bwameth_index_builder
@@ -95,9 +95,9 @@ tools:
 - name: data_manager_gemini_database_downloader
   owner: iuc
   revisions:
-  - 172815da3d41
   - b4b2b284230a
   - 5bcf0e24f42c
+  - 172815da3d41
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_hisat2_index_builder
@@ -134,8 +134,8 @@ tools:
 - name: data_manager_sam_fasta_index_builder
   owner: devteam
   revisions:
-  - f8418a1bf7d0
   - 1865e693d8b2
+  - f8418a1bf7d0
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_snpeff
@@ -148,8 +148,8 @@ tools:
 - name: data_manager_star_index_builder
   owner: iuc
   revisions:
-  - 6c6c6df09e64
   - 64deddb6a8ec
+  - 6c6c6df09e64
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_twobit_builder

--- a/galaxy-aust-staging/phylogenetics.yml
+++ b/galaxy-aust-staging/phylogenetics.yml
@@ -8,22 +8,22 @@ tools:
 - name: hyphy_absrel
   owner: iuc
   revisions:
-  - cce7b18495e4
-  - f73435dc282b
   - 81e66674859e
+  - f73435dc282b
   - c78f3d7dd1db
-  - 107d3ba7024a
   - 8834daeb9892
+  - 107d3ba7024a
+  - cce7b18495e4
   tool_panel_section_label: Phylogenetics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: hyphy_gard
   owner: iuc
   revisions:
-  - 6283babe736e
-  - aa8cc71438cf
   - df47d4845b62
   - 7a2092844346
+  - aa8cc71438cf
   - e75442c7f4da
+  - 6283babe736e
   - 83f146502c0f
   tool_panel_section_label: Phylogenetics
   tool_shed_url: toolshed.g2.bx.psu.edu
@@ -43,16 +43,16 @@ tools:
 - name: raxml
   owner: iuc
   revisions:
-  - ba29b5e2a4be
   - 73a469f7dc96
   - a4b71be30c3c
+  - ba29b5e2a4be
   tool_panel_section_label: Phylogenetics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: roary
   owner: iuc
   revisions:
-  - f1ccc8a6eb05
-  - 15ac71df11a0
   - dbe2b2204555
+  - 15ac71df11a0
+  - f1ccc8a6eb05
   tool_panel_section_label: Phylogenetics
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/picard.yml
+++ b/galaxy-aust-staging/picard.yml
@@ -2,8 +2,8 @@ tools:
 - name: picard
   owner: devteam
   revisions:
-  - f6ced08779c4
   - a1f0b3f4b781
   - fc288950c3b7
+  - f6ced08779c4
   tool_panel_section_label: Picard
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/galaxy-aust-staging/proteomics.yml
+++ b/galaxy-aust-staging/proteomics.yml
@@ -9,8 +9,8 @@ tools:
 - name: cardinal_combine
   owner: galaxyp
   revisions:
-  - b41107d8fe89
   - 525f201b86c1
+  - b41107d8fe89
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: cardinal_data_exporter
@@ -22,8 +22,8 @@ tools:
 - name: cardinal_filtering
   owner: galaxyp
   revisions:
-  - a8157342d9a3
   - 528fb09022be
+  - a8157342d9a3
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: cardinal_mz_images
@@ -72,8 +72,8 @@ tools:
 - name: maldi_quant_peak_detection
   owner: galaxyp
   revisions:
-  - d286ff4600dd
   - e66f552a3c47
+  - d286ff4600dd
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: maldi_quant_preprocessing
@@ -92,8 +92,8 @@ tools:
 - name: maxquant
   owner: galaxyp
   revisions:
-  - 7f432d87c82c
   - ea0a1d50c83f
+  - 7f432d87c82c
   - 2133b0be850a
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
@@ -127,8 +127,8 @@ tools:
 - name: openms_featurefindermultiplex
   owner: galaxyp
   revisions:
-  - dff6c756eee5
   - ca88bd28f116
+  - dff6c756eee5
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_fidoadapter
@@ -141,15 +141,15 @@ tools:
 - name: openms_fileconverter
   owner: galaxyp
   revisions:
-  - 6634cad7d797
   - 5ad0b5bf1deb
+  - 6634cad7d797
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_filefilter
   owner: galaxyp
   revisions:
-  - d6878d27f051
   - 05d5e1ddc985
+  - d6878d27f051
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_fileinfo
@@ -162,22 +162,22 @@ tools:
 - name: openms_filemerger
   owner: galaxyp
   revisions:
-  - 27cba4c5fc42
   - 39e8fde08881
+  - 27cba4c5fc42
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_highresprecursormasscorrector
   owner: galaxyp
   revisions:
-  - 9e26f5c770f8
   - d413dc49d650
+  - 9e26f5c770f8
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_idconflictresolver
   owner: galaxyp
   revisions:
-  - 3720e349ba2a
   - 8a04ed1c1d1b
+  - 3720e349ba2a
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_idfilter
@@ -198,16 +198,16 @@ tools:
 - name: openms_idmerger
   owner: galaxyp
   revisions:
-  - 1c5f31b8d632
   - 18f93351f8b6
+  - 1c5f31b8d632
   - 8d4db262964c
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_idposteriorerrorprobability
   owner: galaxyp
   revisions:
-  - 5d9f175dff81
   - c69f69d7867a
+  - 5d9f175dff81
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_idscoreswitcher
@@ -233,8 +233,8 @@ tools:
 - name: openms_mztabexporter
   owner: galaxyp
   revisions:
-  - 8098330f6d91
   - bf32e0bcf554
+  - 8098330f6d91
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_openswathanalyzer
@@ -294,16 +294,16 @@ tools:
 - name: openms_peakpickerhires
   owner: galaxyp
   revisions:
-  - 3d8d4ada5405
   - 5ae104d0da6e
+  - 3d8d4ada5405
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_peptideindexer
   owner: galaxyp
   revisions:
+  - 5182338d5e7c
   - e039cc5c7aed
   - 539a3a4dcc9e
-  - 5182338d5e7c
   tool_panel_section_label: Proteomics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: openms_proteinquantifier

--- a/galaxy-aust-staging/rna_seq.yml
+++ b/galaxy-aust-staging/rna_seq.yml
@@ -27,8 +27,8 @@ tools:
 - name: cufflinks
   owner: devteam
   revisions:
-  - e04dbae2abe0
   - d080005cffe1
+  - e04dbae2abe0
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: cuffmerge
@@ -54,8 +54,8 @@ tools:
 - name: cummerbund
   owner: devteam
   revisions:
-  - c3b54a4b7741
   - 78fcfc04fcfe
+  - c3b54a4b7741
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: deg_annotate
@@ -74,9 +74,9 @@ tools:
 - name: deseq2
   owner: iuc
   revisions:
-  - 24a09ca67621
-  - 0696db066a5b
   - 71bacea10eee
+  - 0696db066a5b
+  - 24a09ca67621
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: dexseq
@@ -95,8 +95,8 @@ tools:
 - name: edger
   owner: iuc
   revisions:
-  - 9bdff28ae1b1
   - 334ce9b1bac5
+  - 9bdff28ae1b1
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: egsea
@@ -114,10 +114,10 @@ tools:
 - name: featurecounts
   owner: iuc
   revisions:
-  - 90d16db017d7
-  - a37612abf7f9
   - e6a2a912677a
   - f3a5f075498f
+  - a37612abf7f9
+  - 90d16db017d7
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: filter_transcripts_via_tracking
@@ -135,8 +135,8 @@ tools:
 - name: gffcompare
   owner: iuc
   revisions:
-  - 0f710191a66d
   - 3c97c841a443
+  - 0f710191a66d
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: heinz
@@ -249,8 +249,8 @@ tools:
 - name: stringtie
   owner: iuc
   revisions:
-  - 76d290331481
   - 1ebd14235b92
+  - 76d290331481
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: tophat2
@@ -274,8 +274,8 @@ tools:
 - name: trinity_abundance_estimates_to_matrix
   owner: iuc
   revisions:
-  - 59fff1388bc2
   - 74217fbfba4d
+  - 59fff1388bc2
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: trinity_align_and_estimate_abundance
@@ -288,8 +288,8 @@ tools:
 - name: trinity_analyze_diff_expr
   owner: iuc
   revisions:
-  - 56ac80587187
   - c5f02e00d596
+  - 56ac80587187
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: trinity_contig_exn50_statistic
@@ -331,17 +331,17 @@ tools:
 - name: trinity_samples_qccheck
   owner: iuc
   revisions:
-  - 1812dbc5bb7b
   - 7377140e39f8
+  - 1812dbc5bb7b
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: trinity
   owner: iuc
   revisions:
   - cee61b3fcf78
-  - 32b86cd8eb50
-  - db1f362cca3e
   - d84caa5a98ad
+  - db1f362cca3e
+  - 32b86cd8eb50
   tool_panel_section_label: RNA-seq
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: trinotate

--- a/galaxy-aust-staging/sambam.yml
+++ b/galaxy-aust-staging/sambam.yml
@@ -26,9 +26,9 @@ tools:
 - name: qualimap_bamqc
   owner: iuc
   revisions:
-  - 5f8e69cc4c6e
   - e7fd6754d093
   - 19ece8afbaab
+  - 5f8e69cc4c6e
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: qualimap_multi_bamqc
@@ -59,8 +59,8 @@ tools:
 - name: sam_pileup
   owner: devteam
   revisions:
-  - a3b4ad6858ff
   - 890d97772e2a
+  - a3b4ad6858ff
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sam_to_bam
@@ -78,8 +78,8 @@ tools:
 - name: samtools_bedcov
   owner: devteam
   revisions:
-  - 12749212f61b
   - 9149ad20699a
+  - 12749212f61b
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: samtools_calmd
@@ -98,15 +98,15 @@ tools:
 - name: samtools_flagstat
   owner: devteam
   revisions:
-  - 22970df7a40e
   - cc61ade70eb8
+  - 22970df7a40e
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: samtools_idxstats
   owner: devteam
   revisions:
-  - 7a6034296ae9
   - 88b8c2916784
+  - 7a6034296ae9
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: samtools_mpileup
@@ -156,8 +156,8 @@ tools:
 - name: samtools_stats
   owner: devteam
   revisions:
-  - 145f6d74ff5e
   - 24c5d43cb545
+  - 145f6d74ff5e
   tool_panel_section_label: SAM/BAM
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: samtools_view

--- a/galaxy-aust-staging/single_cell.yml
+++ b/galaxy-aust-staging/single_cell.yml
@@ -2,15 +2,15 @@ tools:
 - name: anndata_import
   owner: iuc
   revisions:
-  - 32e547223c9e
   - 00712416fdaa
+  - 32e547223c9e
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: anndata_inspect
   owner: iuc
   revisions:
-  - 39e945f0b2c1
   - b9fac48532eb
+  - 39e945f0b2c1
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: anndata_manipulate
@@ -53,8 +53,8 @@ tools:
 - name: scanpy_filter
   owner: iuc
   revisions:
-  - a97abb8cd15b
   - 3c86f71498bc
+  - a97abb8cd15b
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: scanpy_inspect
@@ -66,22 +66,22 @@ tools:
 - name: scanpy_normalize
   owner: iuc
   revisions:
-  - 3bcd5445cd7a
   - a407e7f8bdc1
+  - 3bcd5445cd7a
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: scanpy_plot
   owner: iuc
   revisions:
-  - dbbe1ea8ecb1
   - 7647e5cd1b8b
+  - dbbe1ea8ecb1
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: scanpy_remove_confounders
   owner: iuc
   revisions:
-  - f2f6c703da06
   - 215733a383f2
+  - f2f6c703da06
   tool_panel_section_label: Single-cell
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: scater_create_qcmetric_ready_sce

--- a/galaxy-aust-staging/statistics.yml
+++ b/galaxy-aust-staging/statistics.yml
@@ -32,8 +32,8 @@ tools:
 - name: datamash_ops
   owner: iuc
   revisions:
-  - 2f3c6f2dcf39
   - 562f3c677828
+  - 2f3c6f2dcf39
   tool_panel_section_label: Statistics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: dwt_cor_ava_perclass
@@ -46,8 +46,8 @@ tools:
 - name: dwt_cor_avb_all
   owner: devteam
   revisions:
-  - 8564f6927b87
   - e01e8a9a82f4
+  - 8564f6927b87
   tool_panel_section_label: Statistics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: dwt_ivc_all
@@ -60,15 +60,15 @@ tools:
 - name: dwt_var_perclass
   owner: devteam
   revisions:
-  - cb422b6f49d2
   - 781e68074f84
+  - cb422b6f49d2
   tool_panel_section_label: Statistics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: dwt_var_perfeature
   owner: devteam
   revisions:
-  - 6c29c7e347e8
   - cb1c59d69557
+  - 6c29c7e347e8
   tool_panel_section_label: Statistics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: generate_pc_lda_matrix
@@ -110,8 +110,8 @@ tools:
 - name: sklearn_build_pipeline
   owner: bgruening
   revisions:
-  - 97dce66fe158
   - 840f29aad145
+  - 97dce66fe158
   tool_panel_section_label: Statistics
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sklearn_estimator_attributes

--- a/galaxy-aust-staging/text_manipulation.yml
+++ b/galaxy-aust-staging/text_manipulation.yml
@@ -21,8 +21,8 @@ tools:
   owner: devteam
   revisions:
   - be25c075ed54
-  - 626658afe4cb
   - 6e8d94597139
+  - 626658afe4cb
   tool_panel_section_label: Text Manipulation
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: concatenate_multiple_datasets
@@ -58,8 +58,8 @@ tools:
 - name: histogram
   owner: devteam
   revisions:
-  - cdb9e89e2970
   - 6f134426c2b0
+  - cdb9e89e2970
   tool_panel_section_label: Text Manipulation
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: join_files_on_column_fuzzy
@@ -72,8 +72,8 @@ tools:
   owner: devteam
   revisions:
   - dd40b1e9eebe
-  - f2aac0c5c60d
   - ae7843d06f8f
+  - f2aac0c5c60d
   tool_panel_section_label: Text Manipulation
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: regex_find_replace

--- a/galaxy-aust-staging/variant_calling.yml
+++ b/galaxy-aust-staging/variant_calling.yml
@@ -8,26 +8,26 @@ tools:
 - name: freebayes
   owner: devteam
   revisions:
-  - ef2c525bd8cd
   - 156b60c1530f
+  - ef2c525bd8cd
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lofreq_alnqual
   owner: iuc
   revisions:
   - e61c9ac190ad
-  - e0e2fd665102
   - 435b157bed6d
+  - e0e2fd665102
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lofreq_call
   owner: iuc
   revisions:
-  - 074d44697036
-  - 03627f24605f
-  - dfadc322b065
   - 3b4b2121842f
   - 65432c3abf6c
+  - 03627f24605f
+  - 074d44697036
+  - dfadc322b065
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lofreq_filter
@@ -41,17 +41,17 @@ tools:
 - name: lofreq_indelqual
   owner: iuc
   revisions:
-  - f4473557ffc7
   - 354b534eeab7
   - c27549b9aa1f
+  - f4473557ffc7
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: lofreq_viterbi
   owner: iuc
   revisions:
+  - cdaab621d454
   - af7e416d8176
   - dbd9f2db9ed8
-  - cdaab621d454
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: sniffles
@@ -63,9 +63,9 @@ tools:
 - name: snippy
   owner: iuc
   revisions:
+  - c9a8ef2aa380
   - 9bccc8404a3c
   - 5bbf9eada9c2
-  - c9a8ef2aa380
   tool_panel_section_label: Variant Calling
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: snp_sites

--- a/galaxy-aust-staging/vcfbcf.yml
+++ b/galaxy-aust-staging/vcfbcf.yml
@@ -2,36 +2,36 @@ tools:
 - name: bcftools_annotate
   owner: iuc
   revisions:
-  - 265fe0f9ea64
   - 8e01baf41774
+  - 265fe0f9ea64
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_call
   owner: iuc
   revisions:
-  - 5801eff9ac7e
   - b03984136ce4
+  - 5801eff9ac7e
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_cnv
   owner: iuc
   revisions:
-  - b2d1b7dda2b7
   - 8408bffd5616
+  - b2d1b7dda2b7
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_concat
   owner: iuc
   revisions:
-  - 874cc12ae316
   - f430a1ec7ee4
+  - 874cc12ae316
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_consensus
   owner: iuc
   revisions:
-  - e522022137f6
   - 1829900b5dcd
+  - e522022137f6
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_convert_from_vcf
@@ -51,29 +51,29 @@ tools:
 - name: bcftools_csq
   owner: iuc
   revisions:
-  - f10f5b4e7854
   - 7cbf3c66d4ad
+  - f10f5b4e7854
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_filter
   owner: iuc
   revisions:
-  - 0117c6d2ab96
   - 963a3635b2e1
+  - 0117c6d2ab96
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_gtcheck
   owner: iuc
   revisions:
-  - fd1030bc93d9
   - 501bfb078342
+  - fd1030bc93d9
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_isec
   owner: iuc
   revisions:
-  - 1fd4fd0c6ee3
   - c803c34361e0
+  - 1fd4fd0c6ee3
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_merge
@@ -100,8 +100,8 @@ tools:
 - name: bcftools_plugin_counts
   owner: iuc
   revisions:
-  - b781fa08aa3c
   - 5ad5d4243987
+  - b781fa08aa3c
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_plugin_dosage
@@ -114,8 +114,8 @@ tools:
 - name: bcftools_plugin_fill_an_ac
   owner: iuc
   revisions:
-  - 3bdc901c18e2
   - 0a62420cb9cd
+  - 3bdc901c18e2
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_plugin_fill_tags
@@ -149,8 +149,8 @@ tools:
 - name: bcftools_plugin_missing2ref
   owner: iuc
   revisions:
-  - 96d0145c041a
   - 5d98fe06e4ae
+  - 96d0145c041a
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_plugin_setgt
@@ -177,15 +177,15 @@ tools:
 - name: bcftools_query
   owner: iuc
   revisions:
-  - 4eb04768cd49
   - c9935c9e8a24
+  - 4eb04768cd49
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_reheader
   owner: iuc
   revisions:
-  - 982bc0e518c8
   - d43eb39b989e
+  - 982bc0e518c8
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bcftools_roh
@@ -212,8 +212,8 @@ tools:
 - name: vcf2tsv
   owner: devteam
   revisions:
-  - e92b3c0f9224
   - 285060661b45
+  - e92b3c0f9224
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcf_annotate
@@ -243,8 +243,8 @@ tools:
 - name: vcfaddinfo
   owner: devteam
   revisions:
-  - 6ea73d6151ec
   - afc0ba768690
+  - 6ea73d6151ec
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfallelicprimitives
@@ -264,15 +264,15 @@ tools:
 - name: vcfannotategenotypes
   owner: devteam
   revisions:
-  - 84959112d9a6
   - 70bc6ced57f7
+  - 84959112d9a6
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfbedintersect
   owner: devteam
   revisions:
-  - 9edfe5145ba8
   - aea8e90ad788
+  - 9edfe5145ba8
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfbreakcreatemulti
@@ -292,8 +292,8 @@ tools:
 - name: vcfcombine
   owner: devteam
   revisions:
-  - 1f0ba67cc85a
   - 53edb91ed051
+  - 1f0ba67cc85a
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfcommonsamples
@@ -320,15 +320,15 @@ tools:
 - name: vcffixup
   owner: devteam
   revisions:
-  - 11f62f071125
   - fc5a64fdd5b2
+  - 11f62f071125
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfflatten
   owner: devteam
   revisions:
-  - f285aa6bdcfb
   - b24e368ae7b1
+  - f285aa6bdcfb
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfgeno2haplo
@@ -348,8 +348,8 @@ tools:
 - name: vcfhethom
   owner: devteam
   revisions:
-  - 8254e0fe7358
   - b07ef36cf7e6
+  - 8254e0fe7358
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfleftalign
@@ -362,8 +362,8 @@ tools:
 - name: vcfprimers
   owner: devteam
   revisions:
-  - 17096387c0e6
   - d226a7327946
+  - 17096387c0e6
   tool_panel_section_label: VCF/BCF
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: vcfrandomsample

--- a/usegalaxy.org.au/annotation.yml
+++ b/usegalaxy.org.au/annotation.yml
@@ -1,0 +1,139 @@
+tools:
+- name: abricate
+  owner: iuc
+  revisions:
+  - 4efdca267d51
+  - 6e9aea89e388
+  - 78c75f134c16
+  - b734db305578
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: annotatemyids
+  owner: iuc
+  revisions:
+  - b5d8e5475247
+  - 1aae04680c4b
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: augustus_training
+  owner: bgruening
+  revisions:
+  - 6519ebe25019
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: barrnap
+  owner: iuc
+  revisions:
+  - 8fd427007e93
+  - 7355bbf5e05f
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: chipseeker
+  owner: rnateam
+  revisions:
+  - 1b9a9409831d
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fgsea
+  owner: iuc
+  revisions:
+  - 17eb1e0d711f
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: goenrichment
+  owner: iuc
+  revisions:
+  - 2c7c9646ccf0
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: goseq
+  owner: iuc
+  revisions:
+  - 8b3e3657034e
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: goslimmer
+  owner: iuc
+  revisions:
+  - de3e053bd6a5
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hmmer3
+  owner: iuc
+  revisions:
+  - 54b6b4d0613a
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: infernal
+  owner: bgruening
+  revisions:
+  - 477d829d3250
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: jcvi_gff_stats
+  owner: iuc
+  revisions:
+  - 8cffbd184762
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maker_map_ids
+  owner: iuc
+  revisions:
+  - 326f9c294b09
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: prokka
+  owner: crs4
+  revisions:
+  - bf68eb663bc3
+  - a17498c603ec
+  - eaee459f3d69
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snap_training
+  owner: iuc
+  revisions:
+  - 2a598c0aa042
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snpeff
+  owner: iuc
+  revisions:
+  - 8f92c2b26e6d
+  - 74aebe30fb52
+  - 68693743661e
+  - 268d162b9c49
+  - 5a29ab10dba6
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snpsift
+  owner: iuc
+  revisions:
+  - 09d6806c609e
+  - 2b3e65a4252f
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snptools
+  owner: rreumerman
+  revisions:
+  - 8de0ffc2166f
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sortmerna
+  owner: rnateam
+  revisions:
+  - eb35257d2e29
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tbprofiler
+  owner: iuc
+  revisions:
+  - 200c378d85f3
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trna_prediction
+  owner: bgruening
+  revisions:
+  - 358f58401cd6
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/assembly.yml
+++ b/usegalaxy.org.au/assembly.yml
@@ -1,0 +1,116 @@
+tools:
+- name: bandage
+  owner: iuc
+  revisions:
+  - b2860df42e16
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: busco
+  owner: iuc
+  revisions:
+  - 5ecdeca79a0d
+  - 1e62c28ba91d
+  - 1440ae06552f
+  - 4048d82f0c88
+  - 382a4c19007f
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: canu
+  owner: bgruening
+  revisions:
+  - c5b7390290b1
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: flye
+  owner: bgruening
+  revisions:
+  - 1ce9b1d72ec3
+  - 3ee0ef312022
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kmergenie
+  owner: rchikhi
+  revisions:
+  - 2d4b0398cbaf
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: megahit
+  owner: iuc
+  revisions:
+  - 7518ee87b53d
+  - de387b2b2803
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metaspades
+  owner: nml
+  revisions:
+  - 05c394313b1c
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: miniasm
+  owner: iuc
+  revisions:
+  - 8dee0218ac7d
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pilon
+  owner: iuc
+  revisions:
+  - 11e5408fd238
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: quast
+  owner: iuc
+  revisions:
+  - f30d03867854
+  - ebb0dcdb621a
+  - 6fcbee531de6
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: racon
+  owner: bgruening
+  revisions:
+  - a199cd7ac344
+  - aa39b19ca11e
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: shovill
+  owner: iuc
+  revisions:
+  - 196a599ec43d
+  - d9f6a00b6db7
+  - 865119fcb694
+  - 57d5928f456e
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: spades
+  owner: nml
+  revisions:
+  - 9006e5836729
+  - b8c00ce5dfa0
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: unicycler
+  owner: iuc
+  revisions:
+  - e92675014ac9
+  - 88c240872a65
+  - 0a3a602cd1e3
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: velvet
+  owner: devteam
+  revisions:
+  - 08256557922f
+  - 5da9a0e2fb2d
+  - 8d09f8be269e
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: velvetoptimiser
+  owner: simon-gladman
+  revisions:
+  - 0e2b4e3f9ca1
+  - d81360ea69d8
+  - 37d88f41c810
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/bacterial_typing.yml
+++ b/usegalaxy.org.au/bacterial_typing.yml
@@ -1,0 +1,16 @@
+tools:
+- name: mlst
+  owner: iuc
+  revisions:
+  - 8e8dc9a1e3e5
+  - 1f5641a52664
+  - ded48b36f3b7
+  tool_panel_section_label: Bacterial Typing
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sistr_cmd
+  owner: nml
+  revisions:
+  - 5c8ff92e38a9
+  - 17fcac7ddf54
+  tool_panel_section_label: Bacterial Typing
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/bed.yml
+++ b/usegalaxy.org.au/bed.yml
@@ -1,0 +1,12 @@
+tools:
+- name: bedtools
+  owner: iuc
+  revisions:
+  - b28e0cfa7ba1
+  - 87ee588b3d45
+  - dde39ba9c031
+  - e19bebe96cd2
+  - a8eabd2838f6
+  - 0a5c785ac6db
+  tool_panel_section_label: BED
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/blast.yml
+++ b/usegalaxy.org.au/blast.yml
@@ -1,0 +1,21 @@
+tools:
+- name: diamond
+  owner: bgruening
+  revisions:
+  - 62c9df8382c2
+  tool_panel_section_label: Blast +
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ncbi_blast_plus
+  owner: devteam
+  revisions:
+  - 6f386c5dc4fb
+  - 2889433c7ae1
+  - e25d3acf6e68
+  tool_panel_section_label: Blast +
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: taxonomy_krona_chart
+  owner: crs4
+  revisions:
+  - 1334cb4c6b68
+  tool_panel_section_label: Blast +
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/chemicaltoolbox.yml
+++ b/usegalaxy.org.au/chemicaltoolbox.yml
@@ -1,0 +1,134 @@
+tools:
+- name: bio3d_pca_visualize
+  owner: chemteam
+  revisions:
+  - f61a718993fd
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bio3d_pca
+  owner: chemteam
+  revisions:
+  - 24867ab16f36
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bio3d_rmsd
+  owner: chemteam
+  revisions:
+  - 77e28e1da9f4
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bio3d_rmsf
+  owner: chemteam
+  revisions:
+  - 6bcb804a54c3
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: chemical_data_sources
+  owner: bgruening
+  revisions:
+  - c2055dd1927b
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ctb_frankenstein_ligand
+  owner: bgruening
+  revisions:
+  - 7255688c77f3
+  - 8e214e52e461
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: enumerate_charges
+  owner: bgruening
+  revisions:
+  - 2a868592ebcb
+  - 36360fa103d6
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: get_pdb
+  owner: bgruening
+  revisions:
+  - 538790c6c21b
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_editconf
+  owner: chemteam
+  revisions:
+  - bfb65cb551d8
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_em
+  owner: chemteam
+  revisions:
+  - 55918daa5651
+  - 476cdf677b03
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_merge_topology_files
+  owner: chemteam
+  revisions:
+  - ced8ec975548
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_setup
+  owner: chemteam
+  revisions:
+  - ccdf0b30a422
+  - 4da9ee404eab
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_sim
+  owner: chemteam
+  revisions:
+  - b1061cc2653a
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmx_solvate
+  owner: chemteam
+  revisions:
+  - 3c77d66e7fe5
+  - 27ea4e1a3f95
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: md_converter
+  owner: chemteam
+  revisions:
+  - 79e8ab8f1e81
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openbabel_compound_convert
+  owner: bgruening
+  revisions:
+  - e6011617c748
+  - 1c66bf08f687
+  - b59c91adeac1
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rdock_rbcavity
+  owner: bgruening
+  revisions:
+  - 7e5c2e4bc227
+  - 744a777e9f90
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rdock_rbdock
+  owner: bgruening
+  revisions:
+  - e4b7d1507a75
+  - a22969b08177
+  - c362398df83b
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sucos_max_score
+  owner: bgruening
+  revisions:
+  - d4c67ced6abc
+  - 85fad59f8168
+  - bf99565cec1f
+  - 55ac04db36aa
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vmd_hbonds
+  owner: chemteam
+  revisions:
+  - 8aa5e465b043
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/chip_seq.yml
+++ b/usegalaxy.org.au/chip_seq.yml
@@ -1,0 +1,43 @@
+tools:
+- name: diffbind
+  owner: bgruening
+  revisions:
+  - c97a786e8fb5
+  - fa56d93f7980
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: genrich
+  owner: iuc
+  revisions:
+  - 8353f3cc03db
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: macs21
+  owner: pjbriggs
+  revisions:
+  - 11cf21ee4242
+  - 4124781932db
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: macs2
+  owner: iuc
+  revisions:
+  - 495a4173006f
+  - f5d67c722d67
+  - 424aefbd7777
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rnachipintegrator
+  owner: pjbriggs
+  revisions:
+  - b695071de766
+  - 087d9872fb0d
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sicer
+  owner: devteam
+  revisions:
+  - 74c9214cc8e6
+  - 4a14714649b4
+  tool_panel_section_label: ChiP-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/collection_operations.yml
+++ b/usegalaxy.org.au/collection_operations.yml
@@ -1,0 +1,37 @@
+tools:
+- name: bundle_collections
+  owner: nml
+  revisions:
+  - 705ebd286b57
+  - cd6da887a5f4
+  tool_panel_section_label: Collection Operations
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: collapse_collections
+  owner: nml
+  revisions:
+  - 33151a38533a
+  - 25136a2b0cfe
+  - 830961c48e42
+  - 90981f86000f
+  tool_panel_section_label: Collection Operations
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: collection_column_join
+  owner: iuc
+  revisions:
+  - 071084070619
+  - dfde09461b1e
+  tool_panel_section_label: Collection Operations
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: split_file_to_collection
+  owner: bgruening
+  revisions:
+  - 6cbe2f30c2d7
+  - d57735dd27b0
+  tool_panel_section_label: Collection Operations
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: unzip
+  owner: imgteam
+  revisions:
+  - 38eec75fbe9b
+  tool_panel_section_label: Collection Operations
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/convert_formats.yml
+++ b/usegalaxy.org.au/convert_formats.yml
@@ -1,0 +1,100 @@
+tools:
+- name: bed_to_protein_map
+  owner: galaxyp
+  revisions:
+  - a7c58b43cbaa
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: biom_add_metadata
+  owner: iuc
+  revisions:
+  - e3cbd2287f63
+  - 367b1ed91207
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: biom_convert
+  owner: iuc
+  revisions:
+  - 584008e574b2
+  - 501c21cce614
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bp_genbank2gff3
+  owner: iuc
+  revisions:
+  - a0d092f27fdf
+  - 11c3eb512633
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_to_tabular
+  owner: devteam
+  revisions:
+  - e7ed3c310b74
+  - 7e801ab2b70e
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_to_fasta
+  owner: devteam
+  revisions:
+  - e282bc27be9a
+  - 186b8d913e6c
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_to_tabular
+  owner: devteam
+  revisions:
+  - ccf4e1d1fcbe
+  - 4b347702c4aa
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fml_gff3togtf
+  owner: vipints
+  revisions:
+  - 5c6f33e20fcc
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gfa_to_fa
+  owner: iuc
+  revisions:
+  - 8e9d604e92f4
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gffcompare_to_bed
+  owner: galaxyp
+  revisions:
+  - 9a4cfc910674
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gffread
+  owner: devteam
+  revisions:
+  - 4dea02886337
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gtftobed12
+  owner: iuc
+  revisions:
+  - b026dae67fba
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tabular_to_fasta
+  owner: devteam
+  revisions:
+  - 0b4e36026794
+  - 0a7799698fe5
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tabular_to_fastq
+  owner: devteam
+  revisions:
+  - b8cdc0507586
+  - 2dcfbbf9071a
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: thermo_raw_file_converter
+  owner: galaxyp
+  revisions:
+  - 63769c4217a7
+  - 26c6706bfb07
+  tool_panel_section_label: Convert Formats
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/deeptools.yml
+++ b/usegalaxy.org.au/deeptools.yml
@@ -1,0 +1,152 @@
+tools:
+- name: deeptools_bam_compare
+  owner: bgruening
+  revisions:
+  - a1ca9bccc7f2
+  - 5f6d123679f4
+  - e821645ef8fc
+  - 268e91e540ee
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_bam_coverage
+  owner: bgruening
+  revisions:
+  - 0e143b4c3987
+  - 7a7fd0f5f15d
+  - 5d11599b8a7d
+  - bb1e4f63e0e6
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_bam_pe_fragmentsize
+  owner: bgruening
+  revisions:
+  - dc059492a995
+  - 81b1e3e1fc6c
+  - 1d848bc4585f
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_bigwig_compare
+  owner: bgruening
+  revisions:
+  - bfff7454b59a
+  - 93eb012d9eed
+  - 71aa86af6762
+  - 26e7304d6737
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_compute_gc_bias
+  owner: bgruening
+  revisions:
+  - 2bc10a9ca58b
+  - dd0b7398bb96
+  - b8858746dc1f
+  - 29fcfd36e90a
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_compute_matrix_operations
+  owner: bgruening
+  revisions:
+  - 72bfafe3330b
+  - ee3a1b0f45f1
+  - c3e012dfe21f
+  - 9384cd033f30
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_compute_matrix
+  owner: bgruening
+  revisions:
+  - b73e213add0c
+  - 514fa53b5efb
+  - 167788df3b46
+  - fd1275e01605
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_correct_gc_bias
+  owner: bgruening
+  revisions:
+  - 2c37ce318bc3
+  - 86febdcc4283
+  - a02cfa31e9cb
+  - c34d11ea4ba6
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_multi_bam_summary
+  owner: bgruening
+  revisions:
+  - 78f405266706
+  - 69a8621ca2f0
+  - 192ef85c0b0b
+  - 2d466b530754
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_multi_bigwig_summary
+  owner: bgruening
+  revisions:
+  - db940c262830
+  - 3c9f0c486cca
+  - 9ecba5e225a6
+  - 2f9e4843f480
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_correlation
+  owner: bgruening
+  revisions:
+  - f264afa9fa6f
+  - bd7db9e2f2cb
+  - fbe773640707
+  - 32e451def88c
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_coverage
+  owner: bgruening
+  revisions:
+  - 7e361d147872
+  - 3b9d990a0a0e
+  - 56bce3c82278
+  - 4e12ea27f788
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_enrichment
+  owner: bgruening
+  revisions:
+  - 94ca68515826
+  - d9114ef1c8a5
+  - ce4ce3316f74
+  - e65d16fb2724
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_fingerprint
+  owner: bgruening
+  revisions:
+  - d57251071381
+  - f8fc4e5aff9d
+  - 2da482e408b8
+  - 23f7c5f1fdaf
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_heatmap
+  owner: bgruening
+  revisions:
+  - c60570fa602f
+  - a7849312d328
+  - a4dfb122e52b
+  - 512155688d98
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_pca
+  owner: bgruening
+  revisions:
+  - 38e3f226248b
+  - 4d678170d29b
+  - 69264da0ce77
+  - aa200e4f3939
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deeptools_plot_profile
+  owner: bgruening
+  revisions:
+  - d806504e96d9
+  - aac8444d6681
+  - c361b12d207a
+  tool_panel_section_label: DeepTools
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/emboss.yml
+++ b/usegalaxy.org.au/emboss.yml
@@ -1,0 +1,8 @@
+tools:
+- name: emboss_5
+  owner: devteam
+  revisions:
+  - 1b6538ec8b56
+  - dba489bfcd62
+  tool_panel_section_label: EMBOSS
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/epigenetics.yml
+++ b/usegalaxy.org.au/epigenetics.yml
@@ -1,0 +1,19 @@
+tools:
+- name: bwameth
+  owner: iuc
+  revisions:
+  - 29bdbc353f20
+  tool_panel_section_label: Epigenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metilene
+  owner: rnateam
+  revisions:
+  - 37abd09a0ae6
+  tool_panel_section_label: Epigenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pileometh
+  owner: bgruening
+  revisions:
+  - 183cb55b1729
+  tool_panel_section_label: Epigenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/fastafastq.yml
+++ b/usegalaxy.org.au/fastafastq.yml
@@ -1,0 +1,279 @@
+tools:
+- name: cutadapt
+  owner: lparsons
+  revisions:
+  - 8665bcc8b847
+  - e4691e1589d3
+  - 660cffd8d92a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_clipping_histogram
+  owner: devteam
+  revisions:
+  - 9db07fd39f85
+  - f666895cbebd
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_compute_length
+  owner: devteam
+  revisions:
+  - de2db1bdfbf8
+  - 7d37cfda8e00
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_concatenate_by_species
+  owner: devteam
+  revisions:
+  - 25b8736c627a
+  - 717aee069681
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_extract
+  owner: simon-gladman
+  revisions:
+  - 5dfc014a8b3a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_filter_by_length
+  owner: devteam
+  revisions:
+  - 8cacfcf96a52
+  - 2fd6033d0e9c
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_formatter
+  owner: devteam
+  revisions:
+  - 9457a20156db
+  - 859422bcb689
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_merge_files_and_filter_unique_sequences
+  owner: galaxyp
+  revisions:
+  - 650d553c1fda
+  - 2904d46167da
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_nucleotide_changer
+  owner: devteam
+  revisions:
+  - f81d4362b6c1
+  - ec0b5076173a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_stats
+  owner: iuc
+  revisions:
+  - 9c620a950d3a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasta_stats
+  owner: simon-gladman
+  revisions:
+  - 20ca2574216a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastp
+  owner: iuc
+  revisions:
+  - dbf9c561ef29
+  - 1d8fe9bc4cb0
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_combiner
+  owner: devteam
+  revisions:
+  - f1dc2a761c30
+  - 56389130cb63
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_filter
+  owner: devteam
+  revisions:
+  - 06934412f56d
+  - 81a9090d6df3
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_groomer
+  owner: devteam
+  revisions:
+  - 71e5fa25b8a2
+  - 47e5dbc3e790
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_manipulation
+  owner: devteam
+  revisions:
+  - 4ac14b275aca
+  - 5b87038565bb
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_masker_by_quality
+  owner: devteam
+  revisions:
+  - 9dfda4e310ed
+  - eb592e9ec47a
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_paired_end_deinterlacer
+  owner: devteam
+  revisions:
+  - f3936d0632cb
+  - b7ce72b00e62
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_paired_end_interlacer
+  owner: devteam
+  revisions:
+  - 2ccb8dcabddc
+  - ef49268ee579
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_paired_end_joiner
+  owner: devteam
+  revisions:
+  - c885369b207b
+  - 822cc1e6274e
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_paired_end_splitter
+  owner: devteam
+  revisions:
+  - 249c8393f2d4
+  - 9bbe5b7ffa12
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_quality_converter
+  owner: devteam
+  revisions:
+  - 74db4cffab1f
+  - 54053ea6c77e
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_stats
+  owner: devteam
+  revisions:
+  - f0e7deab6518
+  - e2cf940128d5
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_trimmer
+  owner: devteam
+  revisions:
+  - b63b2bfb3ea3
+  - 2d0d13b0b0f1
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_artifacts_filter
+  owner: devteam
+  revisions:
+  - d5e9e83cd3d8
+  - 09070cacefd8
+  - 567d5b3c52b1
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_barcode_splitter
+  owner: devteam
+  revisions:
+  - 4bedca26c133
+  - 8abdedf55101
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_clipper
+  owner: devteam
+  revisions:
+  - bdf1ce174e39
+  - 736b8f6ee456
+  - b8658f852bc7
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_collapser
+  owner: devteam
+  revisions:
+  - 421f0af4ee95
+  - 7ce1891db6f5
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_renamer
+  owner: devteam
+  revisions:
+  - b29d37ca9e41
+  - 3599f5451ee2
+  - 02f8a17a4ebd
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_reverse_complement
+  owner: devteam
+  revisions:
+  - e246088b6e34
+  - 0c2907307ba4
+  - 6027ef51ef91
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_trimmer
+  owner: devteam
+  revisions:
+  - 61b4cedc8934
+  - 377ac2829eac
+  - 547e8d00f11c
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ngsutils_bam_filter
+  owner: iuc
+  revisions:
+  - 2e957d4c4b95
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pear
+  owner: iuc
+  revisions:
+  - 2f804526f5fd
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: seq_select_by_id
+  owner: peterjc
+  revisions:
+  - 3b0a14722175
+  - 8e1a90917fa7
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: seqtk
+  owner: iuc
+  revisions:
+  - 58c8ece95b53
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: split_paired_reads
+  owner: devteam
+  revisions:
+  - 36163bff76cc
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trimmomatic
+  owner: pjbriggs
+  revisions:
+  - dfa082f84068
+  - 51b771646466
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ucsc_fasplit
+  owner: iuc
+  revisions:
+  - 71f649c23021
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: umi_tools_count
+  owner: iuc
+  revisions:
+  - b557acca0b56
+  - 276b4111b253
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: umi_tools_extract
+  owner: iuc
+  revisions:
+  - d5ff68d2d5ff
+  - 828dba98cdb4
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/fastq_quality_control.yml
+++ b/usegalaxy.org.au/fastq_quality_control.yml
@@ -1,0 +1,62 @@
+tools:
+- name: fastq_quality_filter
+  owner: devteam
+  revisions:
+  - 7b4468117008
+  - ce9cd02d5b88
+  - e41385662e5e
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_trimmer_by_quality
+  owner: devteam
+  revisions:
+  - c64d534a763c
+  - 8050e091e99b
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastqc
+  owner: devteam
+  revisions:
+  - e7b2202befea
+  - ff9530579d1f
+  - f2e8552cf1d0
+  - 3e1cdf5406db
+  - 2b0c9d9fc6ca
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastqe
+  owner: iuc
+  revisions:
+  - a252d8415583
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_nucleotides_distribution
+  owner: devteam
+  revisions:
+  - ad116ae3f4d9
+  - 18a51655db17
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastx_quality_statistics
+  owner: devteam
+  revisions:
+  - 7306ec78632a
+  - 59003d0543cd
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: multiqc
+  owner: iuc
+  revisions:
+  - 1c2db0054039
+  - 3d93dd18d9f8
+  - bf675f34b056
+  - b2f1f75d49c4
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trim_galore
+  owner: bgruening
+  revisions:
+  - 949f01671246
+  - 084bbd8ba7b8
+  tool_panel_section_label: FASTQ Quality Control
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/fetch_sequencesalignments.yml
+++ b/usegalaxy.org.au/fetch_sequencesalignments.yml
@@ -1,0 +1,7 @@
+tools:
+- name: fraggenescan
+  owner: iuc
+  revisions:
+  - 1f0a3e4497d4
+  tool_panel_section_label: Fetch Sequences/Alignments
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/gemini_tools.yml
+++ b/usegalaxy.org.au/gemini_tools.yml
@@ -1,0 +1,171 @@
+tools:
+- name: gemini_actionable_mutations
+  owner: iuc
+  revisions:
+  - 142d95ab942e
+  - 3630a6e624d4
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_amend
+  owner: iuc
+  revisions:
+  - be828b79bd4d
+  - 4bd4870ecd33
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_annotate
+  owner: iuc
+  revisions:
+  - 0c8f7322f8fc
+  - 8f53b238a360
+  - f2f3bc622a16
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_burden
+  owner: iuc
+  revisions:
+  - df57188562f0
+  - 1a4c5adcd587
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_comp_hets
+  owner: iuc
+  revisions:
+  - 62647e2637f6
+  - 7cf9bc210044
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_db_info
+  owner: iuc
+  revisions:
+  - 7d75673f4d6f
+  - 4c5f4e9b1931
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_de_novo
+  owner: iuc
+  revisions:
+  - 9db3e299b1c8
+  - d5b01cc263be
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_dump
+  owner: iuc
+  revisions:
+  - 40f85b45e472
+  - 96a2d270bf0f
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_fusions
+  owner: iuc
+  revisions:
+  - 91d53f89ca54
+  - 8151a5a0e4f6
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_gene_wise
+  owner: iuc
+  revisions:
+  - 452104bdc655
+  - d46017ddbf94
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_inheritance
+  owner: iuc
+  revisions:
+  - 18d13111692b
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_interactions
+  owner: iuc
+  revisions:
+  - 184aa4e686e2
+  - 2550239feed5
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_load
+  owner: iuc
+  revisions:
+  - b2c25142267e
+  - 45296e47d565
+  - cf61daf064fe
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_lof_sieve
+  owner: iuc
+  revisions:
+  - 2969a1f43b7d
+  - 90021fffff70
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_mendel_errors
+  owner: iuc
+  revisions:
+  - 00c2734b3bea
+  - 61343646155c
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_pathways
+  owner: iuc
+  revisions:
+  - 9199331c3421
+  - 6b09debcfc49
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_qc
+  owner: iuc
+  revisions:
+  - 86e46972e183
+  - 9e83673fa6d2
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_query
+  owner: iuc
+  revisions:
+  - da74170c55c7
+  - 666f60a9331a
+  - 840fb4850be3
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_recessive_and_dominant
+  owner: iuc
+  revisions:
+  - 05124dc72dba
+  - 86f3aac4418d
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_region
+  owner: iuc
+  revisions:
+  - 33efe43c1dbb
+  - 601b70d10d92
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_roh
+  owner: iuc
+  revisions:
+  - 93967598e18e
+  - 345d41f3f574
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_set_somatic
+  owner: iuc
+  revisions:
+  - ef9991a4a9a7
+  - e4e2128460e3
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_stats
+  owner: iuc
+  revisions:
+  - 5c9efee9cb1e
+  - ee894347fcd6
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gemini_windower
+  owner: iuc
+  revisions:
+  - 8f04952b8882
+  - 0c58ba91d018
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/genome_editing.yml
+++ b/usegalaxy.org.au/genome_editing.yml
@@ -1,0 +1,36 @@
+tools:
+- name: mageck_count
+  owner: iuc
+  revisions:
+  - e329d44424d7
+  - 3edbd1ff5602
+  tool_panel_section_label: Genome Editing
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mageck_gsea
+  owner: iuc
+  revisions:
+  - d46e36492bff
+  - b946929d31c4
+  tool_panel_section_label: Genome Editing
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mageck_mle
+  owner: iuc
+  revisions:
+  - 26126538a86f
+  - b36c85e37a48
+  tool_panel_section_label: Genome Editing
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mageck_pathway
+  owner: iuc
+  revisions:
+  - 9744e1124d0f
+  - 39a996d44e16
+  tool_panel_section_label: Genome Editing
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mageck_test
+  owner: iuc
+  revisions:
+  - 688a8eccea71
+  - 9b4f4533c9ee
+  tool_panel_section_label: Genome Editing
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/get_data.yml
+++ b/usegalaxy.org.au/get_data.yml
@@ -1,0 +1,26 @@
+tools:
+- name: dbbuilder
+  owner: galaxyp
+  revisions:
+  - b39347891609
+  - c1b437242fee
+  tool_panel_section_label: Get Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ncbi_acc_download
+  owner: iuc
+  revisions:
+  - 1c58de56d587
+  tool_panel_section_label: Get Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sra_tools
+  owner: iuc
+  revisions:
+  - 1790dcf3c32d
+  - f5ea3ce9b9b0
+  - 8c00bc7fd8de
+  - 7068f48d0ef9
+  - 653e89d73fc4
+  - aad3885b3216
+  - c441583adae5
+  tool_panel_section_label: Get Data
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/graphdisplay_data.yml
+++ b/usegalaxy.org.au/graphdisplay_data.yml
@@ -1,0 +1,156 @@
+tools:
+- name: circos
+  owner: iuc
+  revisions:
+  - ef5f8bbf7730
+  - e6cbe3190642
+  - 740057a5126d
+  - a64dc31ab7f2
+  - 4b519282a05b
+  - fd59d783248a
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: draw_stacked_barplots
+  owner: devteam
+  revisions:
+  - e997b710e38a
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: export2graphlan
+  owner: iuc
+  revisions:
+  - b16989c1e3a7
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastq_quality_boxplot
+  owner: devteam
+  revisions:
+  - 7cf5b1d072b5
+  - f95284aa2946
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ggplot2_heatmap2
+  owner: iuc
+  revisions:
+  - ca7cb0eaad62
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ggplot2_heatmap
+  owner: iuc
+  revisions:
+  - de002ba2b849
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ggplot2_point
+  owner: iuc
+  revisions:
+  - 87908c76ca8d
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gmaj
+  owner: devteam
+  revisions:
+  - 2cd5ee197ec7
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: graphlan_annotate
+  owner: iuc
+  revisions:
+  - cf1df6b2220a
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: graphlan
+  owner: iuc
+  revisions:
+  - a490b70e46fc
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: histogram
+  owner: devteam
+  revisions:
+  - cdb9e89e2970
+  - 6f134426c2b0
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: jbrowse
+  owner: iuc
+  revisions:
+  - 1cfc579079a6
+  - 2bb2e07a7a21
+  - 17359b808b01
+  - ca2def38369c
+  - 112eb40ba6cf
+  - fd5dbf0f732e
+  - 667e17248bfe
+  - 836d1aa3e89a
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: krona_text
+  owner: saskia-hiltemann
+  revisions:
+  - b14f1444e464
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mummer
+  owner: peterjc
+  revisions:
+  - d9f3d4779507
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: newick_utils
+  owner: iuc
+  revisions:
+  - b4163d2f64ab
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: plotly_ml_performance_plots
+  owner: bgruening
+  revisions:
+  - 62e3a4e8c54c
+  - 85da91bbdbfb
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: plotly_parallel_coordinates_plot
+  owner: bgruening
+  revisions:
+  - 9958188c6195
+  - 7b21a9b5922f
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: plotly_regression_performance_plots
+  owner: bgruening
+  revisions:
+  - 389227fa1864
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: prop_venn
+  owner: idot
+  revisions:
+  - cc6707a1e044
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pygenometracks
+  owner: iuc
+  revisions:
+  - 4ac4e7083b7e
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: volcanoplot
+  owner: iuc
+  revisions:
+  - 73b8cb5bddcd
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: weblogo3
+  owner: devteam
+  revisions:
+  - dc25a5169a91
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xy_plot
+  owner: devteam
+  revisions:
+  - ecb437f1d298
+  - 319fa5a9fc1b
+  tool_panel_section_label: Graph/Display Data
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/hicexplorer.yml
+++ b/usegalaxy.org.au/hicexplorer.yml
@@ -1,0 +1,31 @@
+tools:
+- name: hicexplorer_hicbuildmatrix
+  owner: bgruening
+  revisions:
+  - c657edbea349
+  tool_panel_section_label: HiCExplorer
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hicexplorer_hicfindtads
+  owner: bgruening
+  revisions:
+  - 116ddd1627cd
+  tool_panel_section_label: HiCExplorer
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hicexplorer_hicmergematrixbins
+  owner: bgruening
+  revisions:
+  - 9b7840d527be
+  tool_panel_section_label: HiCExplorer
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hicexplorer_hicpca
+  owner: bgruening
+  revisions:
+  - c7f55f65b449
+  tool_panel_section_label: HiCExplorer
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hicexplorer_hicplotmatrix
+  owner: bgruening
+  revisions:
+  - 79acdf9d5e1d
+  tool_panel_section_label: HiCExplorer
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/imaging.yml
+++ b/usegalaxy.org.au/imaging.yml
@@ -1,0 +1,61 @@
+tools:
+- name: 2d_auto_threshold
+  owner: imgteam
+  revisions:
+  - 81f0cbca04a7
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: 2d_feature_extraction
+  owner: imgteam
+  revisions:
+  - 5791a7f65275
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: 2d_filter_segmentation_by_features
+  owner: imgteam
+  revisions:
+  - e576b73a2e2f
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: 2d_histogram_equalization
+  owner: imgteam
+  revisions:
+  - 70316d792fc9
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: 2d_simple_filter
+  owner: imgteam
+  revisions:
+  - dba87c4b32d3
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bfconvert
+  owner: imgteam
+  revisions:
+  - b07f4839ca77
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: binary2labelimage
+  owner: imgteam
+  revisions:
+  - 6e65fd971e13
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: count_objects
+  owner: imgteam
+  revisions:
+  - 664232d2a3f7
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: image_info
+  owner: imgteam
+  revisions:
+  - 7b6d9412c7f8
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: overlay_segmentation_mask
+  owner: imgteam
+  revisions:
+  - 8ad39f493587
+  tool_panel_section_label: Imaging
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/ivar.yml
+++ b/usegalaxy.org.au/ivar.yml
@@ -1,0 +1,57 @@
+tools:
+- name: ivar_consensus
+  owner: iuc
+  revisions:
+  - 78bbd17d0703
+  - a38934e303b9
+  - f362150bef41
+  - d6e72da3ec35
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ivar_filtervariants
+  owner: iuc
+  revisions:
+  - c88553ec696e
+  - 7fe36019c073
+  - f91cfb73d369
+  - 2b95d5c04908
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ivar_getmasked
+  owner: iuc
+  revisions:
+  - fafb3d685fa9
+  - 2cf4a1cafc16
+  - d7e79eb3bcb3
+  - ad0dc9f4c9e2
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ivar_removereads
+  owner: iuc
+  revisions:
+  - 94df24c6bc00
+  - 3d18f8c3c0f6
+  - ee2beb764a7b
+  - bd2a7d1316b9
+  - 9eaadf03e0df
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ivar_trim
+  owner: iuc
+  revisions:
+  - 5d6ed46cc101
+  - db536ad45f28
+  - d37ede8589b2
+  - cb903c9dc33d
+  - 8858fa037a15
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ivar_variants
+  owner: iuc
+  revisions:
+  - f95f403841ad
+  - e1a015876aa9
+  - c5c9f02b6167
+  - 12d66d0d05ac
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/join_subtract_and_group.yml
+++ b/usegalaxy.org.au/join_subtract_and_group.yml
@@ -1,0 +1,7 @@
+tools:
+- name: datamash_transpose
+  owner: iuc
+  revisions:
+  - 22c2a1ac7ae3
+  tool_panel_section_label: Join, Subtract and Group
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/machine_learning.yml
+++ b/usegalaxy.org.au/machine_learning.yml
@@ -1,0 +1,29 @@
+tools:
+- name: sklearn_ensemble
+  owner: bgruening
+  revisions:
+  - 3ab7af14f1b5
+  - 1a53edc4b438
+  tool_panel_section_label: Machine Learning
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_generalized_linear
+  owner: bgruening
+  revisions:
+  - 3e4a7684d402
+  - 91c4e3331208
+  tool_panel_section_label: Machine Learning
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_searchcv
+  owner: bgruening
+  revisions:
+  - 1ae5dfd5ac17
+  - 25ab6b4e376e
+  tool_panel_section_label: Machine Learning
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_svm_classifier
+  owner: bgruening
+  revisions:
+  - d2afc87db26b
+  - f9639b488779
+  tool_panel_section_label: Machine Learning
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/mapping.yml
+++ b/usegalaxy.org.au/mapping.yml
@@ -1,0 +1,46 @@
+tools:
+- name: bowtie2
+  owner: devteam
+  revisions:
+  - 17062a0decb7
+  - 017aba02828d
+  - 937aa69e715f
+  - 749c918495f7
+  - dc1639b66f12
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bwa
+  owner: devteam
+  revisions:
+  - 53646aaaafef
+  - 3fe632431b68
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lastz_paired_reads
+  owner: devteam
+  revisions:
+  - ecc974513241
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lastz
+  owner: devteam
+  revisions:
+  - e7f19d6a9af8
+  - 60afcc2c1d05
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: minimap2
+  owner: iuc
+  revisions:
+  - 8c6cd2650d1f
+  - b3eab4b67562
+  - 53c0b7a1a0c3
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rna_starsolo
+  owner: iuc
+  revisions:
+  - 178bdbdb6d24
+  - e403d27e8f24
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/metabolomics.yml
+++ b/usegalaxy.org.au/metabolomics.yml
@@ -1,0 +1,200 @@
+tools:
+- name: batchcorrection
+  owner: melpetera
+  revisions:
+  - 73892ef177e3
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: camera_annotate
+  owner: lecorguille
+  revisions:
+  - 73d82de36369
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: camera_combinexsannos
+  owner: mmonsoor
+  revisions:
+  - 479a83f62863
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: checkformat
+  owner: ethevenot
+  revisions:
+  - e7c5811ec12f
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: generic_filter
+  owner: melpetera
+  revisions:
+  - 12cf1eed21f4
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: golm_ws_lib_search
+  owner: fgiacomoni
+  revisions:
+  - 28d579fa1718
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hmdb_ms_search
+  owner: fgiacomoni
+  revisions:
+  - 63ba1cb240b7
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lcmsmatching
+  owner: prog
+  revisions:
+  - f86fec07f392
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lipidmaps_textsearch
+  owner: fgiacomoni
+  revisions:
+  - f4e6b77c46e3
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: massbank_ws_searchspectrum
+  owner: fgiacomoni
+  revisions:
+  - 023c380900ef
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metams_rungc
+  owner: yguitton
+  revisions:
+  - c75532b75ba1
+  - c10824185547
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: msnbase_readmsdata
+  owner: lecorguille
+  revisions:
+  - 86a20118e743
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nmr_alignment
+  owner: marie-tremblay-metatoul
+  revisions:
+  - 265ee538e120
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nmr_bucketing
+  owner: marie-tremblay-metatoul
+  revisions:
+  - 4d5c06b46c2f
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nmr_preprocessing
+  owner: marie-tremblay-metatoul
+  revisions:
+  - 5b06800f3449
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: normalization
+  owner: marie-tremblay-metatoul
+  revisions:
+  - f9554d5bb47e
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: probmetab
+  owner: mmonsoor
+  revisions:
+  - 52b222a626b0
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: profia
+  owner: ethevenot
+  revisions:
+  - de9d1270a9ae
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: qualitymetrics
+  owner: ethevenot
+  revisions:
+  - acdf51018708
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tablemerge
+  owner: melpetera
+  revisions:
+  - e44c5246247a
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: univariate
+  owner: ethevenot
+  revisions:
+  - 5687435b182c
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: w4mclassfilter
+  owner: eschen42
+  revisions:
+  - 9f5c0e23c205
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: w4mcorcov
+  owner: eschen42
+  revisions:
+  - 2ae2d26e3270
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: w4mjoinpn
+  owner: eschen42
+  revisions:
+  - dcfaffec48c8
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: withinvariation
+  owner: yguitton
+  revisions:
+  - 5086ad0c0992
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_export_samplemetadata
+  owner: lecorguille
+  revisions:
+  - f39cd33a73a6
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_fillpeaks
+  owner: lecorguille
+  revisions:
+  - 3bc94c3abb28
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_group
+  owner: lecorguille
+  revisions:
+  - fe4002ac5193
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_merge
+  owner: lecorguille
+  revisions:
+  - a301f001835c
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_plot_chromatogram
+  owner: lecorguille
+  revisions:
+  - 271c9d5f0d10
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_retcor
+  owner: lecorguille
+  revisions:
+  - 7faadba7c625
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_summary
+  owner: lecorguille
+  revisions:
+  - acc0a4a366c1
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: xcms_xcmsset
+  owner: lecorguille
+  revisions:
+  - 378ddb410225
+  tool_panel_section_label: Metabolomics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/metagenomic_analysis.yml
+++ b/usegalaxy.org.au/metagenomic_analysis.yml
@@ -1,0 +1,259 @@
+tools:
+- name: cat_bins
+  owner: iuc
+  revisions:
+  - 18676df0cb3a
+  - 0094893f5001
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_prepare
+  owner: iuc
+  revisions:
+  - 8315b5cebb82
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cat_summarise
+  owner: iuc
+  revisions:
+  - 7f1aaa1932d8
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: collector_curve
+  owner: qfab
+  revisions:
+  - 13552951d226
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fasttree
+  owner: iuc
+  revisions:
+  - e005e659ae21
+  - c7e73acfa3eb
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: humann2_genefamilies_genus_level
+  owner: iuc
+  revisions:
+  - 6d364c65c946
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: humann2_regroup_table
+  owner: iuc
+  revisions:
+  - 6aad8ca3918b
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: humann2_renorm_table
+  owner: iuc
+  revisions:
+  - d77397f09da1
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: humann2_unpack_pathways
+  owner: iuc
+  revisions:
+  - 7f208f1eb64f
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: interproscan5
+  owner: bgruening
+  revisions:
+  - e32f2ea6a139
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kraken2
+  owner: iuc
+  revisions:
+  - 328c607150ff
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kraken2tax
+  owner: devteam
+  revisions:
+  - f03c7ba8d8bc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kraken_report
+  owner: devteam
+  revisions:
+  - 6c09bed3444f
+  - 1902d3de4a4f
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kraken_translate
+  owner: devteam
+  revisions:
+  - 9a5be5b1a5c9
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kraken
+  owner: devteam
+  revisions:
+  - aec58624706f
+  - 8ba2174315aa
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maxbin2
+  owner: mbernt
+  revisions:
+  - cfd50144a871
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_pear_stats
+  owner: qfabrepo
+  revisions:
+  - ec62f17fcfe6
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_phyloseq_abundance_factor
+  owner: qfabrepo
+  revisions:
+  - 3856a1590a11
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_phyloseq_abundance_taxonomy
+  owner: qfabrepo
+  revisions:
+  - b2fafdd3533d
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_phyloseq_deseq2
+  owner: qfabrepo
+  revisions:
+  - bb78a1f94f50
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_phyloseq_net
+  owner: qfabrepo
+  revisions:
+  - 22abc415e142
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_phyloseq_richness
+  owner: qfabrepo
+  revisions:
+  - e0225f3e8ef6
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_reheader
+  owner: qfabrepo
+  revisions:
+  - 9cb93e3df272
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_symmetric_plot
+  owner: qfabrepo
+  revisions:
+  - 91fb94d203df
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metadegalaxy_uc2otutable
+  owner: qfabrepo
+  revisions:
+  - 046085ec595c
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metaphlan2krona
+  owner: iuc
+  revisions:
+  - fdbd63e92b01
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: phyloseq_filter
+  owner: simon-gladman
+  revisions:
+  - 54897b7e0551
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: phyloseq_ordination_plot
+  owner: simon-gladman
+  revisions:
+  - 52f009b255a1
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: picrust_categorize
+  owner: iuc
+  revisions:
+  - bee527de98ac
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: picrust_compare_biom
+  owner: iuc
+  revisions:
+  - 0ba7dfaa941d
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: picrust_format_tree_and_trait_table
+  owner: iuc
+  revisions:
+  - 8ab93cd74444
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: picrust_metagenome_contributions
+  owner: iuc
+  revisions:
+  - da4d1ff7009e
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: picrust_normalize_by_copy_number
+  owner: iuc
+  revisions:
+  - 2e62e32d4f33
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: picrust_predict_metagenomes
+  owner: iuc
+  revisions:
+  - 49b6c4392fdc
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pynast
+  owner: qfab
+  revisions:
+  - 17b2737094ce
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rarefaction
+  owner: qfab
+  revisions:
+  - f6c468a79849
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: staramr
+  owner: nml
+  revisions:
+  - 2fd4d4c9c5c2
+  - aeaa20b96ef2
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: usearch_cluster_otus
+  owner: qfab
+  revisions:
+  - 5d05b34a5fdf
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: usearch_dereplication
+  owner: qfab
+  revisions:
+  - 88fc52f1c5db
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: usearch_map_reads_to_otus
+  owner: qfab
+  revisions:
+  - 87603fcae838
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: usearch_uchime
+  owner: qfab
+  revisions:
+  - fd0ab76b83f1
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vsearch
+  owner: iuc
+  revisions:
+  - 576963db5f1b
+  - b3c7199d8786
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/mimodd.yml
+++ b/usegalaxy.org.au/mimodd.yml
@@ -1,0 +1,7 @@
+tools:
+- name: mimodd_main
+  owner: wolma
+  revisions:
+  - bfcd121b99bf
+  tool_panel_section_label: MiModD
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/mothur.yml
+++ b/usegalaxy.org.au/mothur.yml
@@ -1,0 +1,788 @@
+tools:
+- name: mothur_align_check
+  owner: iuc
+  revisions:
+  - 0399e5aeaac6
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_align_seqs
+  owner: iuc
+  revisions:
+  - 152ae632ab19
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_amova
+  owner: iuc
+  revisions:
+  - d0074e20ae76
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_anosim
+  owner: iuc
+  revisions:
+  - 98687b00be79
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_bin_seqs
+  owner: iuc
+  revisions:
+  - 4bf939e17fa4
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_biom_info
+  owner: iuc
+  revisions:
+  - 76d968f820ac
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_bellerophon
+  owner: iuc
+  revisions:
+  - cf1db89b0fda
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_ccode
+  owner: iuc
+  revisions:
+  - b6e0f8a9bc6b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_check
+  owner: iuc
+  revisions:
+  - 4b57c3241cbc
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_perseus
+  owner: iuc
+  revisions:
+  - 0f3baac24045
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_pintail
+  owner: iuc
+  revisions:
+  - 93b61db8bdb6
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_slayer
+  owner: iuc
+  revisions:
+  - 753321ddded9
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_uchime
+  owner: iuc
+  revisions:
+  - f1742cf23d95
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chimera_vsearch
+  owner: iuc
+  revisions:
+  - dd4546e98188
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_chop_seqs
+  owner: iuc
+  revisions:
+  - 29f963e785a0
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_classify_otu
+  owner: iuc
+  revisions:
+  - ec7c3ecca41a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_classify_rf
+  owner: iuc
+  revisions:
+  - 010296966465
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_classify_seqs
+  owner: iuc
+  revisions:
+  - 2f5d4d86eb9a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_classify_tree
+  owner: iuc
+  revisions:
+  - fec1c905cb22
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_clearcut
+  owner: iuc
+  revisions:
+  - 7ad44d831a1f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_cluster_classic
+  owner: iuc
+  revisions:
+  - a649d3ca67b7
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_cluster_fragments
+  owner: iuc
+  revisions:
+  - 5fa9b6d481f6
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_cluster_split
+  owner: iuc
+  revisions:
+  - a9924d4f538f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_cluster
+  owner: iuc
+  revisions:
+  - 5ea1f1f9d801
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_collect_shared
+  owner: iuc
+  revisions:
+  - 44d5c9ba72e6
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_collect_single
+  owner: iuc
+  revisions:
+  - d3b196069f6f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_consensus_seqs
+  owner: iuc
+  revisions:
+  - bc2b62823fcc
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_cooccurrence
+  owner: iuc
+  revisions:
+  - 0e05f58541d0
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_corr_axes
+  owner: iuc
+  revisions:
+  - 1ba1fe2a0438
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_count_groups
+  owner: iuc
+  revisions:
+  - 28867c3771e1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_count_seqs
+  owner: iuc
+  revisions:
+  - 59a962f57cb5
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_create_database
+  owner: iuc
+  revisions:
+  - 319884cd49a3
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_degap_seqs
+  owner: iuc
+  revisions:
+  - 2393ecc7387c
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_deunique_seqs
+  owner: iuc
+  revisions:
+  - 73aeeac872d7
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_deunique_tree
+  owner: iuc
+  revisions:
+  - ec5e03c0f18e
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_dist_seqs
+  owner: iuc
+  revisions:
+  - 502323efbd82
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_dist_shared
+  owner: iuc
+  revisions:
+  - 1a899fec55e1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_fastq_info
+  owner: iuc
+  revisions:
+  - 1edab4936153
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_filter_seqs
+  owner: iuc
+  revisions:
+  - b587a3a485b8
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_filter_shared
+  owner: iuc
+  revisions:
+  - 007311ce6297
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_communitytype
+  owner: iuc
+  revisions:
+  - 4e708ec53432
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_coremicrobiome
+  owner: iuc
+  revisions:
+  - 42244e3619cf
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_dists
+  owner: iuc
+  revisions:
+  - c8fbbada97dc
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_group
+  owner: iuc
+  revisions:
+  - 081d0fbf9751
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_groups
+  owner: iuc
+  revisions:
+  - e4d70a26c19f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_label
+  owner: iuc
+  revisions:
+  - 80b791e2a7bd
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_lineage
+  owner: iuc
+  revisions:
+  - 563718e09fa8
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_mimarkspackage
+  owner: iuc
+  revisions:
+  - 6dbc31423c24
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_otulabels
+  owner: iuc
+  revisions:
+  - fd62ac4a6b84
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_otulist
+  owner: iuc
+  revisions:
+  - f0cf508cdc98
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_oturep
+  owner: iuc
+  revisions:
+  - f821624d355c
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_otus
+  owner: iuc
+  revisions:
+  - 8a67e60260ca
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_rabund
+  owner: iuc
+  revisions:
+  - bd695645069f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_relabund
+  owner: iuc
+  revisions:
+  - b07e7be6326a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_sabund
+  owner: iuc
+  revisions:
+  - a41ba5f5f6b8
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_seqs
+  owner: iuc
+  revisions:
+  - 8b8c7cf6738c
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_get_sharedseqs
+  owner: iuc
+  revisions:
+  - 67faa6dacbae
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_hcluster
+  owner: iuc
+  revisions:
+  - '989184322514'
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_heatmap_bin
+  owner: iuc
+  revisions:
+  - 83d3c6dba0b1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_heatmap_sim
+  owner: iuc
+  revisions:
+  - c2dead9d38c4
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_homova
+  owner: iuc
+  revisions:
+  - 948d5731dbe0
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_indicator
+  owner: iuc
+  revisions:
+  - 39750697d7a6
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_lefse
+  owner: iuc
+  revisions:
+  - d47a909185ef
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_libshuff
+  owner: iuc
+  revisions:
+  - 45a78bb8819d
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_list_otulabels
+  owner: iuc
+  revisions:
+  - e643cc6c39cb
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_list_seqs
+  owner: iuc
+  revisions:
+  - 9b600578c108
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_biom
+  owner: iuc
+  revisions:
+  - e29c05b88096
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_contigs
+  owner: iuc
+  revisions:
+  - f65c34178487
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_design
+  owner: iuc
+  revisions:
+  - 4405d0fbfada
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_fastq
+  owner: iuc
+  revisions:
+  - 1684157db3c1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_group
+  owner: iuc
+  revisions:
+  - 182b471ed56b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_lefse
+  owner: iuc
+  revisions:
+  - 88be2167f369
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_lookup
+  owner: iuc
+  revisions:
+  - a33258dc5bf8
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_shared
+  owner: iuc
+  revisions:
+  - 60f0853e33f3
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_make_sra
+  owner: iuc
+  revisions:
+  - bf608ff56ecf
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_mantel
+  owner: iuc
+  revisions:
+  - bcc475f1af4a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_merge_count
+  owner: iuc
+  revisions:
+  - d5610390efaa
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_merge_files
+  owner: iuc
+  revisions:
+  - 21a9274337f5
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_merge_groups
+  owner: iuc
+  revisions:
+  - f170676a1d12
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_merge_sfffiles
+  owner: iuc
+  revisions:
+  - 26ddda2d2462
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_merge_taxsummary
+  owner: iuc
+  revisions:
+  - 3a2ee62cb710
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_metastats
+  owner: iuc
+  revisions:
+  - fe9f4a0d61d3
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_mimarks_attributes
+  owner: iuc
+  revisions:
+  - 8354a02a83e1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_nmds
+  owner: iuc
+  revisions:
+  - 3cc04a065490
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_normalize_shared
+  owner: iuc
+  revisions:
+  - a8bc62f05cfa
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_otu_association
+  owner: iuc
+  revisions:
+  - a2511c40e7b8
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_otu_hierarchy
+  owner: iuc
+  revisions:
+  - 693fbc55f70e
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_pairwise_seqs
+  owner: iuc
+  revisions:
+  - 4a73df58d56b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_parse_list
+  owner: iuc
+  revisions:
+  - 99579d05a632
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_parsimony
+  owner: iuc
+  revisions:
+  - fd6cebeaa143
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_pca
+  owner: iuc
+  revisions:
+  - 74d1b765843b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_pcoa
+  owner: iuc
+  revisions:
+  - 485e149a8aba
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_pcr_seqs
+  owner: iuc
+  revisions:
+  - 0a23bfe005be
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_phylo_diversity
+  owner: iuc
+  revisions:
+  - c7d41770f4ce
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_phylotype
+  owner: iuc
+  revisions:
+  - 551a2d9c0aa7
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_pre_cluster
+  owner: iuc
+  revisions:
+  - d848e23e9343
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_primer_design
+  owner: iuc
+  revisions:
+  - 487977c2c586
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_rarefaction_shared
+  owner: iuc
+  revisions:
+  - 50312cd2fc7a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_rarefaction_single
+  owner: iuc
+  revisions:
+  - b5bcc4bf53d1
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_dists
+  owner: iuc
+  revisions:
+  - 11795a719c90
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_groups
+  owner: iuc
+  revisions:
+  - 3fac82ad3f01
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_lineage
+  owner: iuc
+  revisions:
+  - 2a4d6c3d9b6d
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_otulabels
+  owner: iuc
+  revisions:
+  - 5133ef623148
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_otus
+  owner: iuc
+  revisions:
+  - 38c03ac3d622
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_rare
+  owner: iuc
+  revisions:
+  - 2531a323f0c2
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_remove_seqs
+  owner: iuc
+  revisions:
+  - eec15ff2d3c9
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_rename_seqs
+  owner: iuc
+  revisions:
+  - ba2b321b6b64
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_reverse_seqs
+  owner: iuc
+  revisions:
+  - f7f5cd1ae299
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_screen_seqs
+  owner: iuc
+  revisions:
+  - a136fc12b26a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_sens_spec
+  owner: iuc
+  revisions:
+  - c3f0b847dc40
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_seq_error
+  owner: iuc
+  revisions:
+  - 2851c368b879
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_sffinfo
+  owner: iuc
+  revisions:
+  - f3a65ee4bfda
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_shhh_flows
+  owner: iuc
+  revisions:
+  - 4e6cdbeaf3b5
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_shhh_seqs
+  owner: iuc
+  revisions:
+  - aa189387c19c
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_sort_seqs
+  owner: iuc
+  revisions:
+  - 334476d3e35d
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_split_abund
+  owner: iuc
+  revisions:
+  - fa40dca23957
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_split_groups
+  owner: iuc
+  revisions:
+  - 99c44fc3cd32
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_sub_sample
+  owner: iuc
+  revisions:
+  - 0f4dfa0332e8
+  - e866e31f6da3
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_summary_qual
+  owner: iuc
+  revisions:
+  - 11be0e5f3ebb
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_summary_seqs
+  owner: iuc
+  revisions:
+  - 4041dc69af62
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_summary_shared
+  owner: iuc
+  revisions:
+  - 81df36f90a1b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_summary_single
+  owner: iuc
+  revisions:
+  - 72be09dfd803
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_summary_tax
+  owner: iuc
+  revisions:
+  - c07510858fb0
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_taxonomy_to_krona
+  owner: iuc
+  revisions:
+  - ec53d27ee602
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_tree_shared
+  owner: iuc
+  revisions:
+  - af2b5be87d4f
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_trim_flows
+  owner: iuc
+  revisions:
+  - 45f3904bfdd2
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_trim_seqs
+  owner: iuc
+  revisions:
+  - dc318dec8b86
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_unifrac_unweighted
+  owner: iuc
+  revisions:
+  - 6a622b34394a
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_unifrac_weighted
+  owner: iuc
+  revisions:
+  - 7cb9b120fd44
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_unique_seqs
+  owner: iuc
+  revisions:
+  - 84722a5b79af
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mothur_venn
+  owner: iuc
+  revisions:
+  - 200defe4c42b
+  tool_panel_section_label: Mothur
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/multiple_alignments.yml
+++ b/usegalaxy.org.au/multiple_alignments.yml
@@ -1,0 +1,20 @@
+tools:
+- name: cdhit
+  owner: bebatut
+  revisions:
+  - 93f25d52cfa5
+  tool_panel_section_label: Multiple Alignments
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: clustalw
+  owner: devteam
+  revisions:
+  - d6694932c5e0
+  tool_panel_section_label: Multiple Alignments
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mafft
+  owner: rnateam
+  revisions:
+  - c5908940967d
+  - 15974dd17515
+  tool_panel_section_label: Multiple Alignments
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/nanopore.yml
+++ b/usegalaxy.org.au/nanopore.yml
@@ -1,0 +1,138 @@
+tools:
+- name: nanocompore_sampcomp
+  owner: iuc
+  revisions:
+  - b833eff63b10
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanofilt
+  owner: leomrtns
+  revisions:
+  - a2c318b04f49
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanoplot
+  owner: iuc
+  revisions:
+  - edbb6c5028f5
+  - 645159bcee2d
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanopolish_eventalign
+  owner: bgruening
+  revisions:
+  - d219b6d8158a
+  - 8fdb079ddaf0
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanopolish_methylation
+  owner: bgruening
+  revisions:
+  - 12efe2f03697
+  - a8d4be409446
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanopolish_polya
+  owner: bgruening
+  revisions:
+  - 449e9aeded2d
+  - be717b65851f
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: nanopolish_variants
+  owner: bgruening
+  revisions:
+  - 63af3144371a
+  - de5b3d8f5b90
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: porechop
+  owner: iuc
+  revisions:
+  - 93d623d9979c
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_events
+  owner: iuc
+  revisions:
+  - 28d7819c312f
+  - 1d835c691480
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_extract
+  owner: iuc
+  revisions:
+  - 7e4f1ed70187
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_hist
+  owner: iuc
+  revisions:
+  - 5a82eb9e1b89
+  - 47936349f3e9
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_nucdist
+  owner: iuc
+  revisions:
+  - a57b6350fd5d
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_occupancy
+  owner: iuc
+  revisions:
+  - 338d15b8d6fb
+  - 336791b5665f
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_qualdist
+  owner: iuc
+  revisions:
+  - ae9060e764b5
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_qualpos
+  owner: iuc
+  revisions:
+  - 4fe6b96aff72
+  - 2e22ebec211a
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_squiggle
+  owner: iuc
+  revisions:
+  - 34553d0caa5e
+  - ce8af9373061
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_stats
+  owner: iuc
+  revisions:
+  - 4b17acf9b6ab
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_tabular
+  owner: iuc
+  revisions:
+  - 2cb2feb94f0e
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_times
+  owner: iuc
+  revisions:
+  - 960be5e0b47e
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_winner
+  owner: iuc
+  revisions:
+  - 79c1ac92f31b
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poretools_yield_plot
+  owner: iuc
+  revisions:
+  - 64a83664b814
+  - ca22d8497db5
+  tool_panel_section_label: Nanopore
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/none.yml
+++ b/usegalaxy.org.au/none.yml
@@ -1,0 +1,894 @@
+tools:
+- name: annotation_profiler
+  owner: devteam
+  revisions:
+  - 3b33da018e74
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_color_chrs
+  owner: iuc
+  revisions:
+  - 71186bb66ca2
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_frameshifts
+  owner: iuc
+  revisions:
+  - 96d2000977ab
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: blast_datatypes
+  owner: devteam
+  revisions:
+  - 01b38f20197e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: charts
+  owner: iuc
+  revisions:
+  - a87a3773d8ed
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_bowtie2_index_builder
+  owner: devteam
+  revisions:
+  - 1c0f8e9d87c6
+  - 83da94c0e4a6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_build_kraken2_database
+  owner: iuc
+  revisions:
+  - edacc4bcd3cb
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_bwa_mem_index_builder
+  owner: devteam
+  revisions:
+  - 46066df8813d
+  - 37580590ecfb
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_bwameth_index_builder
+  owner: iuc
+  revisions:
+  - 5ab25caa7b7d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_cat
+  owner: iuc
+  revisions:
+  - cffd8e2382cf
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_diamond_database_builder
+  owner: bgruening
+  revisions:
+  - 5a0d0bee4f8d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_fetch_busco
+  owner: iuc
+  revisions:
+  - 53eec20e8fb6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+  revisions:
+  - b1bc53e9bbc5
+  - 4d3eff1bc421
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_gatk_picard_index_builder
+  owner: devteam
+  revisions:
+  - b31f1fcb203c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_gemini_database_downloader
+  owner: iuc
+  revisions:
+  - 172815da3d41
+  - b4b2b284230a
+  - f57426daa04d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_hisat2_index_builder
+  owner: iuc
+  revisions:
+  - d210e1f185bd
+  - 8eac26f44d29
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_humann2_database_downloader
+  owner: iuc
+  revisions:
+  - 9244804f69a7
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_kallisto_index_builder
+  owner: iuc
+  revisions:
+  - 6843a0db2da0
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_metaphlan2_database_downloader
+  owner: iuc
+  revisions:
+  - 9c4ad82be5bd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_mothur_toolsuite
+  owner: iuc
+  revisions:
+  - aec831b54a5b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_sam_fasta_index_builder
+  owner: devteam
+  revisions:
+  - 1865e693d8b2
+  - f8418a1bf7d0
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_snpeff
+  owner: iuc
+  revisions:
+  - 08d7998c3afb
+  - a6400027d849
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_star_index_builder
+  owner: iuc
+  revisions:
+  - 6c6c6df09e64
+  - 64deddb6a8ec
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_twobit_builder
+  owner: devteam
+  revisions:
+  - 9946bc39c834
+  - 16c0c73b28ad
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: differential_count_models
+  owner: fubar
+  revisions:
+  - 3107df74056e
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: emboss_datatypes
+  owner: devteam
+  revisions:
+  - a89163f31369
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: idr_package
+  owner: modencode-dcc
+  revisions:
+  - 6f6a9fbe264e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: metagenomics_datatypes
+  owner: qfab
+  revisions:
+  - edf752012785
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mira_datatypes
+  owner: peterjc
+  revisions:
+  - ddd2e3362c5e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: molecule_datatypes
+  owner: iuc
+  revisions:
+  - 85eca06eefc6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: msa_datatypes
+  owner: iuc
+  revisions:
+  - 70227007b991
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: no_unzip_datatype
+  owner: lecorguille
+  revisions:
+  - 7800ba9a4c1e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_atlas_3_10
+  owner: iuc
+  revisions:
+  - 98c017ec230d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_atlas_3_10
+  owner: iuc
+  revisions:
+  - 35d6b30ef137
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_bcftools_1_3
+  owner: iuc
+  revisions:
+  - 43a9aebf3adb
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_bioc_qvalue_1_34_0
+  owner: devteam
+  revisions:
+  - 11735242a19e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_biopython_1_65
+  owner: biopython
+  revisions:
+  - d8185f5631ed
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_biopython_1_67
+  owner: biopython
+  revisions:
+  - a12f73c3b116
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_blast_plus_2_2_28
+  owner: iuc
+  revisions:
+  - 222036f7cab6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_blast_plus_2_5_0
+  owner: iuc
+  revisions:
+  - 5dd2b68c7d04
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_blast_plus_2_7_1
+  owner: iuc
+  revisions:
+  - 2e9109a8924f
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_bowtie_0_12_7
+  owner: devteam
+  revisions:
+  - 9f9f38617a98
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_bowtie_1_0_0
+  owner: iuc
+  revisions:
+  - 9fcaaedbbfd6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_bx_python_0_7
+  owner: devteam
+  revisions:
+  - 2d0c08728bca
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_bzlib_1_0
+  owner: iuc
+  revisions:
+  - af4887e1f595
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_cairo_1_12_14
+  owner: devteam
+  revisions:
+  - cd2ed5717e38
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_cairo_1_12_14
+  owner: devteam
+  revisions:
+  - f1cf1dd60867
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_cairo_1_12_14
+  owner: iuc
+  revisions:
+  - 0a73735c3161
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_cmake_3_2_3
+  owner: iuc
+  revisions:
+  - 1aea698a1c63
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_cummerbund_2_8_2
+  owner: iuc
+  revisions:
+  - 754912f24120
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_datamash_1_0_6
+  owner: iuc
+  revisions:
+  - 414953c0168d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_eigen_3_1
+  owner: iuc
+  revisions:
+  - baedf7f82cc3
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_express_1_1_1
+  owner: devteam
+  revisions:
+  - 29ace4b8ed87
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_fastx_toolkit_0_0_13
+  owner: devteam
+  revisions:
+  - ec66ae4c269b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_fontconfig_2_11_1
+  owner: iuc
+  revisions:
+  - d88d844df0cb
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_fontconfig_2_11_1
+  owner: iuc
+  revisions:
+  - 66bcc0972d16
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_freetype_2_4
+  owner: iuc
+  revisions:
+  - 77d40d53da67
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_freetype_2_5_2
+  owner: devteam
+  revisions:
+  - a65217367e4a
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_freetype_2_5_2
+  owner: devteam
+  revisions:
+  - 34ebf47e4941
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_freetype_2_5_2
+  owner: iuc
+  revisions:
+  - 1e86d1cf79a4
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_freetype_2_5_2
+  owner: iuc
+  revisions:
+  - 22887dea4683
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_gdbm_1_11
+  owner: iuc
+  revisions:
+  - ed2537bccffc
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_gemini_0_18_1
+  owner: iuc
+  revisions:
+  - 49de32b47548
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_ghostscript_9_10
+  owner: devteam
+  revisions:
+  - a285e78179bd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_ghostscript_9_10
+  owner: devteam
+  revisions:
+  - 9345d2740f0c
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_gnuplot_4_6
+  owner: iuc
+  revisions:
+  - 2d356c5a1354
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_graphicsmagick_1_3
+  owner: iuc
+  revisions:
+  - 9b0d84b880e4
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_hmmer_3_1b1
+  owner: iuc
+  revisions:
+  - ee143f73fee0
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_imaging_1_1_7
+  owner: iuc
+  revisions:
+  - 428ac4a9db59
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_kraken_0_10_6_eaf8fb68
+  owner: iuc
+  revisions:
+  - 0743afe4dcb8
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_lastz_1_02_00
+  owner: devteam
+  revisions:
+  - 1d4a5e764543
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libcurl_7_35
+  owner: iuc
+  revisions:
+  - 0d934b13250c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libgd_2_1
+  owner: iuc
+  revisions:
+  - 9ff7903354f2
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libpng_1_6_7
+  owner: devteam
+  revisions:
+  - 3de32cd300a9
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libpng_1_6_7
+  owner: devteam
+  revisions:
+  - 833849e0ddfc
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_libpng_1_6_7
+  owner: iuc
+  revisions:
+  - 588666932a32
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libpng_1_6_7
+  owner: iuc
+  revisions:
+  - d1a409e4f67d
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_libtool_2_4
+  owner: iuc
+  revisions:
+  - 7f67694b167c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libxml2_2_9_1
+  owner: iuc
+  revisions:
+  - 45b16a3ab504
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_libxml2_2_9_1
+  owner: iuc
+  revisions:
+  - 492a5c665b59
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_matplotlib_1_2
+  owner: iuc
+  revisions:
+  - 8096e96d5076
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_mothur
+  owner: qfab
+  revisions:
+  - 150982d8fd53
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_mummer_3_23
+  owner: iuc
+  revisions:
+  - 9ddc606546c3
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_ncurses_5_9
+  owner: iuc
+  revisions:
+  - 335ebf512407
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_ncurses_5_9
+  owner: iuc
+  revisions:
+  - ad27910a950c
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_ncurses_6_0
+  owner: iuc
+  revisions:
+  - 0efde9889efd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_numpy_1_7
+  owner: iuc
+  revisions:
+  - 5c489d2d630b
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_numpy_1_7
+  owner: iuc
+  revisions:
+  - '300877695495'
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_numpy_1_8
+  owner: qfab
+  revisions:
+  - 36659940cecb
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_numpy_1_9
+  owner: iuc
+  revisions:
+  - 83d12e13dbbd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_openbabel_2_3
+  owner: iuc
+  revisions:
+  - ae369c08a2a7
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pandas_0_14
+  owner: iuc
+  revisions:
+  - ac9f317487a9
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_phyml_3_1
+  owner: vlefort
+  revisions:
+  - 7f68b38e2be1
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_picard_1_56_0
+  owner: devteam
+  revisions:
+  - 99a28567c3a3
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pixman_0_32_4
+  owner: devteam
+  revisions:
+  - 93cd8e03820c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pixman_0_32_4
+  owner: devteam
+  revisions:
+  - 7056a708062b
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_pixman_0_32_4
+  owner: iuc
+  revisions:
+  - 32ff063c4de8
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pixman_0_32_6
+  owner: iuc
+  revisions:
+  - 06f701aa92e2
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pycogent_1_5_2
+  owner: qfab
+  revisions:
+  - fbe9f90728fc
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_pysam_0_7_6
+  owner: iuc
+  revisions:
+  - 247e5e5bee87
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_python_2_7_10
+  owner: iuc
+  revisions:
+  - bd7165ea6526
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_python_2_7_numpy_1_9
+  owner: iuc
+  revisions:
+  - f24fc0b630fc
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_python_2_7_six_1_10_0
+  owner: iuc
+  revisions:
+  - 6944ba405057
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_python_2_7
+  owner: iuc
+  revisions:
+  - f761bd14343e
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_2_11_0
+  owner: devteam
+  revisions:
+  - 5824d2b3bc8b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_2_15_0
+  owner: devteam
+  revisions:
+  - 6c34eaa82fed
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_3_1_2
+  owner: iuc
+  revisions:
+  - 1ca39eb16186
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_r_3_1_2
+  owner: iuc
+  revisions:
+  - 4d2fd1413b56
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_3_2_1
+  owner: iuc
+  revisions:
+  - d9f7d84125b7
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_batch_1_1_4
+  owner: lecorguille
+  revisions:
+  - e8a964ca8656
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_r_ggplot2_0_9_3
+  owner: iuc
+  revisions:
+  - 07de191649b4
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_readline_6_2
+  owner: iuc
+  revisions:
+  - 5313ca2fbce6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_readline_6_2
+  owner: iuc
+  revisions:
+  - 1007a3015bdb
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_readline_6_3
+  owner: iuc
+  revisions:
+  - ca1a9400d4e1
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_rpy2_2_7_8
+  owner: iuc
+  revisions:
+  - 304bc0447631
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_rpy_1_0_3
+  owner: devteam
+  revisions:
+  - 82170c94ca7c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_rsem_1_1_17
+  owner: jjohnson
+  revisions:
+  - cd7f70d4c687
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_samtools_0_1_16
+  owner: devteam
+  revisions:
+  - 3cc494fb5a14
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_samtools_0_1_18
+  owner: devteam
+  revisions:
+  - 171cd8bc208d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_samtools_0_1_19
+  owner: iuc
+  revisions:
+  - c9bd782f5342
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_samtools_1_2
+  owner: iuc
+  revisions:
+  - f6ae3ba3f3c1
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_sicer_1_1
+  owner: devteam
+  revisions:
+  - 48c84c1cab2b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_snippy_3_0
+  owner: simon-gladman
+  revisions:
+  - c8d7d39f0781
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_sqlite_3_8_3
+  owner: iuc
+  revisions:
+  - c8a5c11cc921
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_tabix_0_2_6
+  owner: iuc
+  revisions:
+  - 389d2376b60b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_taxonomy_1_0_0
+  owner: devteam
+  revisions:
+  - c011d4659306
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_tiff_4_0_3
+  owner: iuc
+  revisions:
+  - 2c2c0ccd0f37
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: package_tophat2_2_0_9
+  owner: devteam
+  revisions:
+  - 8549fd545473
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_uclust_1_2_22q
+  owner: qfab
+  revisions:
+  - c0295ba21771
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_vcftools_0_1_11
+  owner: devteam
+  revisions:
+  - 710efaae2ff8
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_velvet_1_2_10
+  owner: devteam
+  revisions:
+  - 93d32326537b
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_velvet_1_2_10
+  owner: simon-gladman
+  revisions:
+  - a6d81014257d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_vsearch_1_9_7
+  owner: iuc
+  revisions:
+  - 99c947b9fb31
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_xz_5_0_5
+  owner: iuc
+  revisions:
+  - 944f93d45594
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_zlib_1_2_8
+  owner: iuc
+  revisions:
+  - 411985b46ae8
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: package_zlib_1_2_8
+  owner: iuc
+  revisions:
+  - 3348f1acee2a
+  tool_panel_section_label: None
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: proteomics_datatypes
+  owner: iracooke
+  revisions:
+  - 300fc3aa6954
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: qualimap_counts
+  owner: iuc
+  revisions:
+  - d696cf0a9622
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rdata_camera_datatypes
+  owner: lecorguille
+  revisions:
+  - 4a51ab3d8ecf
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rdata_xcms_datatypes
+  owner: lecorguille
+  revisions:
+  - 544f6d2329ac
+  - d64562a4ebb3
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rsem_datatypes
+  owner: jjohnson
+  revisions:
+  - 77151afcd323
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: smagexp_datatypes
+  owner: sblanck
+  revisions:
+  - f174dc3d2641
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: spp_tool
+  owner: stemcellcommons
+  revisions:
+  - 23b22c1692fa
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: suite_bcftools_1_3
+  owner: iuc
+  revisions:
+  - 488e382af384
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: suite_biom_format
+  owner: iuc
+  revisions:
+  - 8eda049e45c2
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: suite_deeptools
+  owner: bgruening
+  revisions:
+  - 3d68b716965a
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: suite_trinity
+  owner: iuc
+  revisions:
+  - 96786204c3fc
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/operate_on_genomic_intervals.yml
+++ b/usegalaxy.org.au/operate_on_genomic_intervals.yml
@@ -1,0 +1,67 @@
+tools:
+- name: basecoverage
+  owner: devteam
+  revisions:
+  - 2cedec3759e4
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cluster
+  owner: devteam
+  revisions:
+  - 05696474ee89
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: complement
+  owner: devteam
+  revisions:
+  - 38c8bb402872
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: concat
+  owner: devteam
+  revisions:
+  - 35a89f8cc96e
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: coverage
+  owner: devteam
+  revisions:
+  - 4ef9819dc7fb
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: flanking_features
+  owner: devteam
+  revisions:
+  - a09d13b108fd
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: get_flanks
+  owner: devteam
+  revisions:
+  - 077f404ae1bb
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: join
+  owner: devteam
+  revisions:
+  - a10f49d9218a
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: merge
+  owner: devteam
+  revisions:
+  - 381cd27bf67a
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: subtract_query
+  owner: devteam
+  revisions:
+  - ff3901618482
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: subtract
+  owner: devteam
+  revisions:
+  - 0145969324c4
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/phylogenetics.yml
+++ b/usegalaxy.org.au/phylogenetics.yml
@@ -1,0 +1,59 @@
+tools:
+- name: gubbins
+  owner: iuc
+  revisions:
+  - 637ec5d5368c
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hyphy_absrel
+  owner: iuc
+  revisions:
+  - 8834daeb9892
+  - 81e66674859e
+  - c78f3d7dd1db
+  - 107d3ba7024a
+  - cce7b18495e4
+  - f73435dc282b
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hyphy_gard
+  owner: iuc
+  revisions:
+  - 83f146502c0f
+  - df47d4845b62
+  - 7a2092844346
+  - aa8cc71438cf
+  - e75442c7f4da
+  - 6283babe736e
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: iqtree
+  owner: iuc
+  revisions:
+  - d1c340a5664b
+  - f97743d52b87
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: phyml
+  owner: vlefort
+  revisions:
+  - 6dd988b4b760
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raxml
+  owner: iuc
+  revisions:
+  - a4b71be30c3c
+  - 73a469f7dc96
+  - ba29b5e2a4be
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: roary
+  owner: iuc
+  revisions:
+  - 15ac71df11a0
+  - 809e42326fc2
+  - f1ccc8a6eb05
+  - dbe2b2204555
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/picard.yml
+++ b/usegalaxy.org.au/picard.yml
@@ -1,0 +1,9 @@
+tools:
+- name: picard
+  owner: devteam
+  revisions:
+  - a1f0b3f4b781
+  - f6ced08779c4
+  - fc288950c3b7
+  tool_panel_section_label: Picard
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/proteomics.yml
+++ b/usegalaxy.org.au/proteomics.yml
@@ -1,0 +1,345 @@
+tools:
+- name: cardinal_classification
+  owner: galaxyp
+  revisions:
+  - 277dc652246e
+  - 42f6e30b00f2
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_combine
+  owner: galaxyp
+  revisions:
+  - b41107d8fe89
+  - 525f201b86c1
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_data_exporter
+  owner: galaxyp
+  revisions:
+  - 90d2e00e1304
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_filtering
+  owner: galaxyp
+  revisions:
+  - 528fb09022be
+  - a8157342d9a3
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_mz_images
+  owner: galaxyp
+  revisions:
+  - 4a05e47cd0ea
+  - a69865da6f80
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_preprocessing
+  owner: galaxyp
+  revisions:
+  - ed9ed1e6cca2
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_quality_report
+  owner: galaxyp
+  revisions:
+  - 19f68d9ae773
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_segmentations
+  owner: galaxyp
+  revisions:
+  - b16b64ca7b7c
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cardinal_spectra_plots
+  owner: galaxyp
+  revisions:
+  - f17b01ec5c22
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dia_umpire
+  owner: galaxyp
+  revisions:
+  - 2b785516abfc
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: flashlfq
+  owner: galaxyp
+  revisions:
+  - 92c059f90d0e
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maldi_quant_peak_detection
+  owner: galaxyp
+  revisions:
+  - e66f552a3c47
+  - d286ff4600dd
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maldi_quant_preprocessing
+  owner: galaxyp
+  revisions:
+  - 71411ac28268
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maxquant_mqpar
+  owner: galaxyp
+  revisions:
+  - 3fc2116ac6d9
+  - 2d67fb758956
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: maxquant
+  owner: galaxyp
+  revisions:
+  - 2133b0be850a
+  - 7f432d87c82c
+  - ea0a1d50c83f
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: morpheus
+  owner: galaxyp
+  revisions:
+  - e0104a9f20f0
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_consensusid
+  owner: galaxyp
+  revisions:
+  - 8960fb791701
+  - 4e77b8f12cd3
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_falsediscoveryrate
+  owner: galaxyp
+  revisions:
+  - f7fef900f5b2
+  - 518b1730cf2a
+  - 9cdf15d3cfc8
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_featurefindermultiplex
+  owner: galaxyp
+  revisions:
+  - ca88bd28f116
+  - dff6c756eee5
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_fidoadapter
+  owner: galaxyp
+  revisions:
+  - 890025d6e426
+  - 41859bbdc16e
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_fileconverter
+  owner: galaxyp
+  revisions:
+  - 6634cad7d797
+  - 5ad0b5bf1deb
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_filefilter
+  owner: galaxyp
+  revisions:
+  - 05d5e1ddc985
+  - d6878d27f051
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_fileinfo
+  owner: galaxyp
+  revisions:
+  - febd569ad26f
+  - 5ad830edc021
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_filemerger
+  owner: galaxyp
+  revisions:
+  - 39e8fde08881
+  - 27cba4c5fc42
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_highresprecursormasscorrector
+  owner: galaxyp
+  revisions:
+  - d413dc49d650
+  - 9e26f5c770f8
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idconflictresolver
+  owner: galaxyp
+  revisions:
+  - 3720e349ba2a
+  - 8a04ed1c1d1b
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idfilter
+  owner: galaxyp
+  revisions:
+  - c427a8628cbe
+  - 382cde407f81
+  - c55dddc5844a
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idmapper
+  owner: galaxyp
+  revisions:
+  - 8ddb7bab1138
+  - b5d0905419da
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idmerger
+  owner: galaxyp
+  revisions:
+  - 8d4db262964c
+  - 18f93351f8b6
+  - 1c5f31b8d632
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idposteriorerrorprobability
+  owner: galaxyp
+  revisions:
+  - 5d9f175dff81
+  - c69f69d7867a
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_idscoreswitcher
+  owner: galaxyp
+  revisions:
+  - 476b5e296979
+  - 0e52c85f3b15
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_msgfplusadapter
+  owner: galaxyp
+  revisions:
+  - a407b6790342
+  - 2b2a7551a857
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_multiplexresolver
+  owner: galaxyp
+  revisions:
+  - 4e66c4e73909
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_mztabexporter
+  owner: galaxyp
+  revisions:
+  - bf32e0bcf554
+  - 8098330f6d91
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathanalyzer
+  owner: galaxyp
+  revisions:
+  - a2a6e9551046
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathassaygenerator
+  owner: galaxyp
+  revisions:
+  - 8c01da82292c
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathconfidencescoring
+  owner: galaxyp
+  revisions:
+  - 3d24698daa6e
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathdecoygenerator
+  owner: galaxyp
+  revisions:
+  - 9f505cd4428f
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathdiaprescoring
+  owner: galaxyp
+  revisions:
+  - 0bddef8d144e
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathfilesplitter
+  owner: galaxyp
+  revisions:
+  - 8b814eafce2c
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathmzmlfilecacher
+  owner: galaxyp
+  revisions:
+  - 05ec9fb05ed1
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathrtnormalizer
+  owner: galaxyp
+  revisions:
+  - 18826fb8e5db
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_openswathworkflow
+  owner: galaxyp
+  revisions:
+  - bc63b4d12779
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_peakpickerhires
+  owner: galaxyp
+  revisions:
+  - 5ae104d0da6e
+  - 3d8d4ada5405
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_peptideindexer
+  owner: galaxyp
+  revisions:
+  - 5182338d5e7c
+  - 539a3a4dcc9e
+  - e039cc5c7aed
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_proteinquantifier
+  owner: galaxyp
+  revisions:
+  - e992ed59d3e5
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_textexporter
+  owner: galaxyp
+  revisions:
+  - 1294873c8d1d
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: openms_xtandemadapter
+  owner: galaxyp
+  revisions:
+  - c8b225c69a7f
+  - fb52e95a370c
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: peptideshaker
+  owner: galaxyp
+  revisions:
+  - 7fdd9119cc4f
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: percolator
+  owner: galaxyp
+  revisions:
+  - 07107a686ce9
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: proteomics_moff
+  owner: galaxyp
+  revisions:
+  - a96af68dafb2
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rawtools
+  owner: galaxyp
+  revisions:
+  - 51e4aa55ea04
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/rad_seq.yml
+++ b/usegalaxy.org.au/rad_seq.yml
@@ -1,0 +1,73 @@
+tools:
+- name: stacks2_clonefilter
+  owner: iuc
+  revisions:
+  - 2f1d464ebfd2
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_cstacks
+  owner: iuc
+  revisions:
+  - fcce77c09289
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_denovomap
+  owner: iuc
+  revisions:
+  - 421c33b8bf17
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_gstacks
+  owner: iuc
+  revisions:
+  - 1d839ead7ad3
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_kmerfilter
+  owner: iuc
+  revisions:
+  - 8a55d29c8fcf
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_populations
+  owner: iuc
+  revisions:
+  - b242deb58952
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_procrad
+  owner: iuc
+  revisions:
+  - bd5ff77e2036
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_refmap
+  owner: iuc
+  revisions:
+  - 6dafad990086
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_shortreads
+  owner: iuc
+  revisions:
+  - 43e3eeb2e0ec
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_sstacks
+  owner: iuc
+  revisions:
+  - 0b8c84a7fdb5
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_tsv2bam
+  owner: iuc
+  revisions:
+  - bf0e43ab0416
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stacks2_ustacks
+  owner: iuc
+  revisions:
+  - d033e1ccb386
+  tool_panel_section_label: RAD-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/rna_seq.yml
+++ b/usegalaxy.org.au/rna_seq.yml
@@ -1,0 +1,367 @@
+tools:
+- name: blockbuster
+  owner: rnateam
+  revisions:
+  - 7c7ff7a3503f
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: blockclust
+  owner: rnateam
+  revisions:
+  - aab6cf87b40a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cuffcompare
+  owner: devteam
+  revisions:
+  - f648e5180e40
+  - e66b9b5b8580
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cuffdiff
+  owner: devteam
+  revisions:
+  - 43b36b3d4333
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cufflinks
+  owner: devteam
+  revisions:
+  - e04dbae2abe0
+  - d080005cffe1
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cuffmerge
+  owner: devteam
+  revisions:
+  - 6a6717a5f421
+  - cf747d1bd79a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cuffnorm
+  owner: devteam
+  revisions:
+  - 9a854107dbb2
+  - 6cbfede05833
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cuffquant
+  owner: devteam
+  revisions:
+  - 679d93c99757
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cummerbund
+  owner: devteam
+  revisions:
+  - 78fcfc04fcfe
+  - c3b54a4b7741
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deg_annotate
+  owner: iuc
+  revisions:
+  - e98d4ab5b5bc
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: describe_samples
+  owner: iuc
+  revisions:
+  - 8bfbdb039d4e
+  - 8f0181aacb7a
+  - 0693ccd171c4
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: deseq2
+  owner: iuc
+  revisions:
+  - 0696db066a5b
+  - 71bacea10eee
+  - 24a09ca67621
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dexseq
+  owner: iuc
+  revisions:
+  - f1c406f9554c
+  - 9fd8b69e6e68
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: edger
+  owner: iuc
+  revisions:
+  - 9bdff28ae1b1
+  - 334ce9b1bac5
+  - 555659de7321
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: egsea
+  owner: iuc
+  revisions:
+  - 31ea4992b948
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: express
+  owner: devteam
+  revisions:
+  - 7b0708761d05
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: featurecounts
+  owner: iuc
+  revisions:
+  - af814359d244
+  - 90d16db017d7
+  - a37612abf7f9
+  - e6a2a912677a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: filter_transcripts_via_tracking
+  owner: devteam
+  revisions:
+  - 45f89dcf0b4c
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: generate_count_matrix
+  owner: jchung
+  revisions:
+  - 56768aac1758
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: gffcompare
+  owner: iuc
+  revisions:
+  - 0f710191a66d
+  - 3c97c841a443
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: heinz
+  owner: iuc
+  revisions:
+  - 2b80a2596064
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: hisat2
+  owner: iuc
+  revisions:
+  - 764756ab0eb5
+  - 3fb01a8c902d
+  - 0c16cad5e03b
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: htseq_bams_to_count_matrix
+  owner: fubar
+  revisions:
+  - d300bc688e95
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: htseq_count
+  owner: lparsons
+  revisions:
+  - 7f5a8d427b39
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kallisto_pseudo
+  owner: iuc
+  revisions:
+  - 1c75aa5de15e
+  - 5ae5c312d718
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: kallisto_quant
+  owner: iuc
+  revisions:
+  - 10c98fab6c5a
+  - 60f888039fb2
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: limma_voom
+  owner: iuc
+  revisions:
+  - 97e06a4c7c75
+  - 0921444c832d
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mirdeep2_mapper
+  owner: rnateam
+  revisions:
+  - dbbe92348c7a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mirdeep2_quantifier
+  owner: rnateam
+  revisions:
+  - d5ea61ff12eb
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: mirdeep2
+  owner: rnateam
+  revisions:
+  - 6a17e1229b9f
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pipe_t
+  owner: davidecangelosi
+  revisions:
+  - e4281dad3291
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: qualimap_rnaseq
+  owner: iuc
+  revisions:
+  - 43a1c3e1a4d0
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: repenrich
+  owner: artbio
+  revisions:
+  - 6f4143893463
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rgrnastar
+  owner: iuc
+  revisions:
+  - 5ec75f5dae3c
+  - 0a563fd2f22e
+  - 99b17b74a8cd
+  - b9e04854e2bb
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: rsem
+  owner: jjohnson
+  revisions:
+  - 14267d364365
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sailfish
+  owner: bgruening
+  revisions:
+  - a8f343909c17
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: salmon
+  owner: bgruening
+  revisions:
+  - e3d32471da11
+  - 53e9709776a0
+  - b265be7af3db
+  - 6b0ba6de1424
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: stringtie
+  owner: iuc
+  revisions:
+  - 76d290331481
+  - 1ebd14235b92
+  - dd4df992d93d
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tophat2
+  owner: devteam
+  revisions:
+  - 16c4255042be
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tophat_fusion_post
+  owner: devteam
+  revisions:
+  - f83394a2c2da
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: transdecoder
+  owner: iuc
+  revisions:
+  - 0db979fead3a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_abundance_estimates_to_matrix
+  owner: iuc
+  revisions:
+  - 74217fbfba4d
+  - d6a479fd4281
+  - 59fff1388bc2
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_align_and_estimate_abundance
+  owner: iuc
+  revisions:
+  - 478f36effca1
+  - 56162e446004
+  - 04bd98a9c751
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_analyze_diff_expr
+  owner: iuc
+  revisions:
+  - 56ac80587187
+  - c5f02e00d596
+  - fab23c3b5258
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_contig_exn50_statistic
+  owner: iuc
+  revisions:
+  - 34a018cbee9c
+  - 62b05e565a45
+  - 4687ecf0eb2d
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_define_clusters_by_cutting_tree
+  owner: iuc
+  revisions:
+  - 55292a66e7c1
+  - 05ab8d5e04a2
+  - 33406f5a445c
+  - c5fbddcac63a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_filter_low_expr_transcripts
+  owner: iuc
+  revisions:
+  - e406ac71165d
+  - 42c5172815f7
+  - 6f0fb35b799c
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_gene_to_trans_map
+  owner: iuc
+  revisions:
+  - 297a1c03c702
+  - 37a1129c89d2
+  - c2c039e421af
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_run_de_analysis
+  owner: iuc
+  revisions:
+  - 1d689e4e1caf
+  - 04936df18de3
+  - 047c22569787
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity_samples_qccheck
+  owner: iuc
+  revisions:
+  - 9871104ea630
+  - 1812dbc5bb7b
+  - 7377140e39f8
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinity
+  owner: iuc
+  revisions:
+  - c9cfec002f71
+  - db1f362cca3e
+  - d84caa5a98ad
+  - cee61b3fcf78
+  - 32b86cd8eb50
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: trinotate
+  owner: iuc
+  revisions:
+  - 6fd16fad465d
+  - 9e61bc67866f
+  - 4383070d29ed
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/rseqc.yml
+++ b/usegalaxy.org.au/rseqc.yml
@@ -1,0 +1,8 @@
+tools:
+- name: rseqc
+  owner: nilesh
+  revisions:
+  - 080fd5739bb4
+  - f437057e46f1
+  tool_panel_section_label: RSeQC
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/sambam.yml
+++ b/usegalaxy.org.au/sambam.yml
@@ -1,0 +1,175 @@
+tools:
+- name: bam_to_sam
+  owner: devteam
+  revisions:
+  - 88eedb4abea0
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bamtools_filter
+  owner: devteam
+  revisions:
+  - cb20f99fd45b
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pileup_interval
+  owner: devteam
+  revisions:
+  - ef11139d4545
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: pileup_parser
+  owner: devteam
+  revisions:
+  - 85bedbea8a12
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: qualimap_bamqc
+  owner: iuc
+  revisions:
+  - e7fd6754d093
+  - 19ece8afbaab
+  - 5f8e69cc4c6e
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: qualimap_multi_bamqc
+  owner: iuc
+  revisions:
+  - e38af83df163
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sam2interval
+  owner: devteam
+  revisions:
+  - 75557c0908a9
+  - 8c737b8ddc45
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sam_bitwise_flag_filter
+  owner: devteam
+  revisions:
+  - 0b2424a404d9
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sam_merge
+  owner: devteam
+  revisions:
+  - 1977f1637890
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sam_pileup
+  owner: devteam
+  revisions:
+  - 890d97772e2a
+  - a3b4ad6858ff
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sam_to_bam
+  owner: devteam
+  revisions:
+  - cf1ffd88f895
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtool_filter2
+  owner: devteam
+  revisions:
+  - 649a225999a5
+  - dc6ff68ea5e8
+  - 56c31114ad4a
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_bedcov
+  owner: devteam
+  revisions:
+  - 9149ad20699a
+  - 12749212f61b
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_calmd
+  owner: devteam
+  revisions:
+  - 33208952b99d
+  - 06dc50b7b711
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_fastx
+  owner: iuc
+  revisions:
+  - a8d69aee190e
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_flagstat
+  owner: devteam
+  revisions:
+  - cc61ade70eb8
+  - 22970df7a40e
+  - 4e404acfafa6
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_idxstats
+  owner: devteam
+  revisions:
+  - 04d5581db1f5
+  - 7a6034296ae9
+  - 88b8c2916784
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_mpileup
+  owner: devteam
+  revisions:
+  - 583abf29fc8e
+  - fa7ad9b89f4a
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_phase
+  owner: devteam
+  revisions:
+  - b5c3b1856370
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_reheader
+  owner: devteam
+  revisions:
+  - db000c6007a0
+  - 30388d878f81
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_rmdup
+  owner: devteam
+  revisions:
+  - 586f9e1cdb2b
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_slice_bam
+  owner: devteam
+  revisions:
+  - a4a10c7924d1
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_sort
+  owner: devteam
+  revisions:
+  - cab3f8d35989
+  - e613c1ad4c4c
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_split
+  owner: devteam
+  revisions:
+  - b7f7826ef1cd
+  - 135c85f4cfaf
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_stats
+  owner: devteam
+  revisions:
+  - 24c5d43cb545
+  - 793ad847121d
+  - 145f6d74ff5e
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_view
+  owner: iuc
+  revisions:
+  - b01db2684fa5
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/single_cell.yml
+++ b/usegalaxy.org.au/single_cell.yml
@@ -1,0 +1,122 @@
+tools:
+- name: anndata_import
+  owner: iuc
+  revisions:
+  - 00712416fdaa
+  - 32e547223c9e
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: anndata_inspect
+  owner: iuc
+  revisions:
+  - b9fac48532eb
+  - 39e945f0b2c1
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: anndata_manipulate
+  owner: iuc
+  revisions:
+  - d4af736e7b83
+  - 43cb7b5a6fe7
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dropletutils
+  owner: iuc
+  revisions:
+  - cdf4443d5625
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raceid_clustering
+  owner: iuc
+  revisions:
+  - 7e014059a88d
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raceid_filtnormconf
+  owner: iuc
+  revisions:
+  - 7608d5faee41
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raceid_inspectclusters
+  owner: iuc
+  revisions:
+  - 37a47c4fd84d
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raceid_inspecttrajectory
+  owner: iuc
+  revisions:
+  - 69018f285aa3
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: raceid_trajectory
+  owner: iuc
+  revisions:
+  - 44b935f2271b
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_cluster_reduce_dimension
+  owner: iuc
+  revisions:
+  - 77b91b9bdf52
+  - b2df381a6004
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_filter
+  owner: iuc
+  revisions:
+  - a97abb8cd15b
+  - 3c86f71498bc
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_inspect
+  owner: iuc
+  revisions:
+  - 5e9171dc8244
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_normalize
+  owner: iuc
+  revisions:
+  - 3bcd5445cd7a
+  - a407e7f8bdc1
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_plot
+  owner: iuc
+  revisions:
+  - dbbe1ea8ecb1
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scanpy_remove_confounders
+  owner: iuc
+  revisions:
+  - f2f6c703da06
+  - 215733a383f2
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scater_create_qcmetric_ready_sce
+  owner: iuc
+  revisions:
+  - fd808de478b1
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scater_filter
+  owner: iuc
+  revisions:
+  - b7ea9f09c02f
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scater_plot_dist_scatter
+  owner: iuc
+  revisions:
+  - 2e41b35b5bdd
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: scater_plot_pca
+  owner: iuc
+  revisions:
+  - 46fc6751d746
+  tool_panel_section_label: Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/statistics.yml
+++ b/usegalaxy.org.au/statistics.yml
@@ -1,0 +1,141 @@
+tools:
+- name: categorize_elements_satisfying_criteria
+  owner: devteam
+  revisions:
+  - 586c1f0e1515
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: compute_motif_frequencies_for_all_motifs
+  owner: devteam
+  revisions:
+  - 5319efa51514
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: compute_motifs_frequency
+  owner: devteam
+  revisions:
+  - 1f8ee7f9701b
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: correlation
+  owner: devteam
+  revisions:
+  - 24e01abf9e34
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: count_gff_features
+  owner: devteam
+  revisions:
+  - 188392a0d0a8
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: datamash_ops
+  owner: iuc
+  revisions:
+  - 562f3c677828
+  - 2f3c6f2dcf39
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dwt_cor_ava_perclass
+  owner: devteam
+  revisions:
+  - b87bbe6bc044
+  - a0defff5cf89
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dwt_cor_avb_all
+  owner: devteam
+  revisions:
+  - 8564f6927b87
+  - e01e8a9a82f4
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dwt_ivc_all
+  owner: devteam
+  revisions:
+  - 0b89b03ad760
+  - 506ae7b0d85d
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dwt_var_perclass
+  owner: devteam
+  revisions:
+  - 781e68074f84
+  - cb422b6f49d2
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: dwt_var_perfeature
+  owner: devteam
+  revisions:
+  - 6c29c7e347e8
+  - cb1c59d69557
+  - 7a15159140d1
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: generate_pc_lda_matrix
+  owner: devteam
+  revisions:
+  - 04cdbd00dcec
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: iwtomics_plotwithscale
+  owner: iuc
+  revisions:
+  - 1bc9150ed125
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: iwtomics_testandplot
+  owner: iuc
+  revisions:
+  - 94965e369be4
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: plot_from_lda
+  owner: devteam
+  revisions:
+  - 08affc5d2aef
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: poisson2test
+  owner: devteam
+  revisions:
+  - 5ff18ec88181
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: row_means
+  owner: simon-gladman
+  revisions:
+  - 33493e25c51c
+  tool_panel_section_label: Statistics
+  tool_shed_url: testtoolshed.g2.bx.psu.edu
+- name: sklearn_build_pipeline
+  owner: bgruening
+  revisions:
+  - 97dce66fe158
+  - 840f29aad145
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_estimator_attributes
+  owner: bgruening
+  revisions:
+  - bd27a211182a
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_nn_classifier
+  owner: bgruening
+  revisions:
+  - 39ae3c043096
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sklearn_numeric_clustering
+  owner: bgruening
+  revisions:
+  - 1dd433d2c92c
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: t_test_two_samples
+  owner: devteam
+  revisions:
+  - c2ffc9885b5a
+  tool_panel_section_label: Statistics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/text_manipulation.yml
+++ b/usegalaxy.org.au/text_manipulation.yml
@@ -1,0 +1,101 @@
+tools:
+- name: add_value
+  owner: devteam
+  revisions:
+  - 745871c0b055
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: collection_element_identifiers
+  owner: iuc
+  revisions:
+  - d3c07d270a50
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: column_arrange_by_header
+  owner: bgruening
+  revisions:
+  - f18f67056946
+  - 6c6d26ff01ff
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: column_maker
+  owner: devteam
+  revisions:
+  - be25c075ed54
+  - 464b9305180e
+  - 6e8d94597139
+  - 626658afe4cb
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: concatenate_multiple_datasets
+  owner: artbio
+  revisions:
+  - 6f54dc6b37da
+  - 3a4694d4354f
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: concatenate_multiple_datasets
+  owner: mvdbeek
+  revisions:
+  - 201c568972c3
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: condense_characters
+  owner: devteam
+  revisions:
+  - 381ed54c5e39
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: cut_include_exclude
+  owner: r-lannes
+  revisions:
+  - d28ee835a561
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: join_files_on_column_fuzzy
+  owner: bgruening
+  revisions:
+  - 22ec3c1a20cd
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: merge_cols
+  owner: devteam
+  revisions:
+  - ae7843d06f8f
+  - f2aac0c5c60d
+  - dd40b1e9eebe
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: regex_find_replace
+  owner: galaxyp
+  revisions:
+  - ae8c4b2488e7
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: replace_column_by_key_value_file
+  owner: bgruening
+  revisions:
+  - d533e4b75800
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sqlite_to_tabular
+  owner: iuc
+  revisions:
+  - 4678715f7147
+  - b722161a845a
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: table_compute
+  owner: iuc
+  revisions:
+  - 60ff16842fcd
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: text_processing
+  owner: bgruening
+  revisions:
+  - a6f147a050a2
+  - 9ff72e942410
+  - 0a8c6b61f0f4
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/variant_calling.yml
+++ b/usegalaxy.org.au/variant_calling.yml
@@ -1,0 +1,142 @@
+tools:
+- name: breseq
+  owner: iuc
+  revisions:
+  - 85c57cc9b558
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: freebayes
+  owner: devteam
+  revisions:
+  - ef2c525bd8cd
+  - 156b60c1530f
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lofreq_alnqual
+  owner: iuc
+  revisions:
+  - e61c9ac190ad
+  - 435b157bed6d
+  - e0e2fd665102
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lofreq_call
+  owner: iuc
+  revisions:
+  - 3b4b2121842f
+  - 65432c3abf6c
+  - 074d44697036
+  - dfadc322b065
+  - 03627f24605f
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lofreq_filter
+  owner: iuc
+  revisions:
+  - 701d134358ad
+  - 950d1d49d678
+  - 9cb929f21cfa
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lofreq_indelqual
+  owner: iuc
+  revisions:
+  - f4473557ffc7
+  - 354b534eeab7
+  - c27549b9aa1f
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: lofreq_viterbi
+  owner: iuc
+  revisions:
+  - af7e416d8176
+  - dbd9f2db9ed8
+  - cdaab621d454
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: sniffles
+  owner: iuc
+  revisions:
+  - 93c4b04a0769
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snippy
+  owner: iuc
+  revisions:
+  - c9a8ef2aa380
+  - 5bbf9eada9c2
+  - 9bccc8404a3c
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snp_sites
+  owner: iuc
+  revisions:
+  - 5804f786060d
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snpeff_sars_cov_2
+  owner: iuc
+  revisions:
+  - 2a3a00c1fa0a
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: snpfreq
+  owner: devteam
+  revisions:
+  - 5c3ac057608b
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: substitution_rates
+  owner: devteam
+  revisions:
+  - 3d9544198582
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tb_variant_filter
+  owner: iuc
+  revisions:
+  - 3b1e7c170b10
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: tbvcfreport
+  owner: iuc
+  revisions:
+  - 02d81b994ef5
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: varscan_version_2
+  owner: devteam
+  revisions:
+  - bc1e0cd41241
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcf_annotate
+  owner: devteam
+  revisions:
+  - b001b50f2009
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcf_extract
+  owner: devteam
+  revisions:
+  - 76ad0b7865b9
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcf_filter
+  owner: devteam
+  revisions:
+  - da1a6f33b504
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcf_intersect
+  owner: devteam
+  revisions:
+  - 9d162bde4113
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcftools_merge
+  owner: devteam
+  revisions:
+  - 71e19ddf52f5
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/vcfbcf.yml
+++ b/usegalaxy.org.au/vcfbcf.yml
@@ -1,0 +1,427 @@
+tools:
+- name: bcftools_annotate
+  owner: iuc
+  revisions:
+  - 6a88248893c4
+  - 8e01baf41774
+  - 265fe0f9ea64
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_call
+  owner: iuc
+  revisions:
+  - b03984136ce4
+  - 5801eff9ac7e
+  - 0fba2c15b40d
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_cnv
+  owner: iuc
+  revisions:
+  - 8408bffd5616
+  - b2d1b7dda2b7
+  - bf1f4994f104
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_concat
+  owner: iuc
+  revisions:
+  - 874cc12ae316
+  - 0c4d4d19a193
+  - f430a1ec7ee4
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_consensus
+  owner: iuc
+  revisions:
+  - e522022137f6
+  - 2363ef414c9b
+  - 1829900b5dcd
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_convert_from_vcf
+  owner: iuc
+  revisions:
+  - 92c0aff8b53e
+  - 09f37afb3621
+  - 7ca6120cb2a4
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_convert_to_vcf
+  owner: iuc
+  revisions:
+  - 8bb5efd7a3dd
+  - 1f2183a23823
+  - 367ba501b6eb
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_csq
+  owner: iuc
+  revisions:
+  - 039ea3f1dea9
+  - 7cbf3c66d4ad
+  - f10f5b4e7854
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_filter
+  owner: iuc
+  revisions:
+  - 0117c6d2ab96
+  - cdb7b4927742
+  - 963a3635b2e1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_gtcheck
+  owner: iuc
+  revisions:
+  - a1213a0b7b66
+  - 501bfb078342
+  - fd1030bc93d9
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_isec
+  owner: iuc
+  revisions:
+  - 1fd4fd0c6ee3
+  - 709dd8291b83
+  - c803c34361e0
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_merge
+  owner: iuc
+  revisions:
+  - 85ee7e6c4204
+  - 9473302f4588
+  - 7ba36babba2d
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_mpileup
+  owner: iuc
+  revisions:
+  - 9c711df3258d
+  - cf06b44624c7
+  - f65383c7ed49
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_norm
+  owner: iuc
+  revisions:
+  - 19905c025d2a
+  - a62e934346f5
+  - a404f786a94c
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_counts
+  owner: iuc
+  revisions:
+  - 5ad5d4243987
+  - 71c78e0eea52
+  - b781fa08aa3c
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_dosage
+  owner: iuc
+  revisions:
+  - 2ee1392161a6
+  - d31a2e310a52
+  - 0fe007201caf
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_fill_an_ac
+  owner: iuc
+  revisions:
+  - 0a62420cb9cd
+  - 026a989b7cee
+  - 3bdc901c18e2
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_fill_tags
+  owner: iuc
+  revisions:
+  - bca7ce81688f
+  - e493702b19eb
+  - cbfa272e5a6a
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_fixploidy
+  owner: iuc
+  revisions:
+  - 12152af85697
+  - ceb03be4f31b
+  - 157ffcdd3fa7
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_impute_info
+  owner: iuc
+  revisions:
+  - 2c53c8974cb3
+  - 6f8e223f78f3
+  - 29ba253e2e05
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_mendelian
+  owner: iuc
+  revisions:
+  - 3ff5654b4e7d
+  - 98664595dedf
+  - a367a15c6de5
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_missing2ref
+  owner: iuc
+  revisions:
+  - 5d98fe06e4ae
+  - 96d0145c041a
+  - 31c096c6b156
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_setgt
+  owner: iuc
+  revisions:
+  - 46eb13bc2c73
+  - 09f5e45a8212
+  - 76fe872413c2
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_plugin_tag2tag
+  owner: iuc
+  revisions:
+  - 0594ea1417c8
+  - 6cbb9c47795c
+  - aa998b9898b1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_query_list_samples
+  owner: iuc
+  revisions:
+  - 242753783b68
+  - 473f814b74d5
+  - adee7e8b746f
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_query
+  owner: iuc
+  revisions:
+  - 4eb04768cd49
+  - e0ad88dec40d
+  - c9935c9e8a24
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_reheader
+  owner: iuc
+  revisions:
+  - 982bc0e518c8
+  - 2a9cfd8f653e
+  - d43eb39b989e
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_roh
+  owner: iuc
+  revisions:
+  - 5296d26b0373
+  - b0d39ef600a7
+  - cb681f21e670
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_stats
+  owner: iuc
+  revisions:
+  - b641062a2587
+  - baa8823f8073
+  - 9c0028888512
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bcftools_view
+  owner: iuc
+  revisions:
+  - d1f8f55f564d
+  - c4a9b38b435d
+  - 3a233c8eb814
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcf2tsv
+  owner: devteam
+  revisions:
+  - e92b3c0f9224
+  - 285060661b45
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfaddinfo
+  owner: devteam
+  revisions:
+  - 6ea73d6151ec
+  - afc0ba768690
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfallelicprimitives
+  owner: devteam
+  revisions:
+  - a8a4f94aa321
+  - 57a16b310fe8
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfannotate
+  owner: devteam
+  revisions:
+  - 01e0321aca98
+  - 6faa2c4c71d2
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfannotategenotypes
+  owner: devteam
+  revisions:
+  - 70bc6ced57f7
+  - 84959112d9a6
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfbedintersect
+  owner: devteam
+  revisions:
+  - 9edfe5145ba8
+  - aea8e90ad788
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfbreakcreatemulti
+  owner: devteam
+  revisions:
+  - 690b1d846263
+  - 9fd5d91eb91b
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfcheck
+  owner: devteam
+  revisions:
+  - 2968c6916579
+  - 5e850c85ba32
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfcombine
+  owner: devteam
+  revisions:
+  - 53edb91ed051
+  - 1f0ba67cc85a
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfcommonsamples
+  owner: devteam
+  revisions:
+  - 254f285dbaaa
+  - f1852ecef841
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfdistance
+  owner: devteam
+  revisions:
+  - 48e458c721b3
+  - 5822b40f3037
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcffilter
+  owner: devteam
+  revisions:
+  - eae7c08ebb6f
+  - fa24bf0598f4
+  - 6b935ab36d7b
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcffixup
+  owner: devteam
+  revisions:
+  - fc5a64fdd5b2
+  - 11f62f071125
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfflatten
+  owner: devteam
+  revisions:
+  - f285aa6bdcfb
+  - b24e368ae7b1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfgeno2haplo
+  owner: devteam
+  revisions:
+  - b890055e07bd
+  - a3dea556218d
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfgenotypes
+  owner: devteam
+  revisions:
+  - a60ae8af21a1
+  - f5653ed90dfd
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfhethom
+  owner: devteam
+  revisions:
+  - 8254e0fe7358
+  - b07ef36cf7e6
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfleftalign
+  owner: devteam
+  revisions:
+  - d2406f98a782
+  - 29f9b782727e
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfprimers
+  owner: devteam
+  revisions:
+  - d226a7327946
+  - 17096387c0e6
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfrandomsample
+  owner: devteam
+  revisions:
+  - 12b570dd0bc5
+  - 6257ee3b50d3
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfselectsamples
+  owner: devteam
+  revisions:
+  - 2ba3b87f904f
+  - 958b6484a7f1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfsort
+  owner: devteam
+  revisions:
+  - 5b7120c66efc
+  - f0580efedada
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcftools_annotate
+  owner: devteam
+  revisions:
+  - 57a6550df582
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcftools_isec
+  owner: devteam
+  revisions:
+  - aa232e38338f
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcftools_slice
+  owner: devteam
+  revisions:
+  - 1363e5d4a8b8
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcftools_subset
+  owner: devteam
+  revisions:
+  - 23436d1d0fa1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: vcfvcfintersect
+  owner: devteam
+  revisions:
+  - 166c4f50525f
+  - 6f6bf10618d7
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/usegalaxy.org.au/viral_tools.yml
+++ b/usegalaxy.org.au/viral_tools.yml
@@ -1,0 +1,7 @@
+tools:
+- name: quasitools
+  owner: nml
+  revisions:
+  - 9def47f3c1e4
+  tool_panel_section_label: Viral Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
This reverts commit 8fd9c64f23fc395596f0865e2ade97f0f06ccdb0.

Galaxy production was unavailable at the moment the get-tool-list was called and because there are no checks around this, Jenkins deleted the yaml files.

The only files altered in this PR are within galaxy-aust-staging/ and usegalaxy.org.au/ directories.

