### PR TITLE
very simple installation script for new staging

### DIFF
--- a/jenkins/simple_install_test.sh
+++ b/jenkins/simple_install_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. ~/jobs_common/.venv3/bin/activate
+
+TOOL_FILE=$1
+SECTION=$(echo $(basename $TOOL_FILE) | cut -d'.' -f 1)
+
+if [ ! $URL ] || [ ! $API_KEY ] || [ ! $LOG_DIR ]; then
+    echo "Expecting URL, API_KEY, LOG_DIR to be in context" # set these in Jenkins bash script
+    exit 1;
+fi
+
+INSTALL_LOG=${LOG_DIR}/${SECTION}_install_log.txt
+TEST_LOG=${LOG_DIR}/${SECTION}_test_log.txt
+TEST_JSON=${LOG_DIR}/${SECTION}_test.json
+TEST_HTML=${LOG_DIR}/${SECTION}_test.html
+
+shed-tools install -g ${URL} -a ${API_KEY} -t ${TOOL_FILE} -v --log_file ${INSTALL_LOG}
+shed-tools test -g ${URL} -a ${API_KEY} -t ${TOOL_FILE} --parallel_tests 4 --test_json ${TEST_JSON} -v --log_file ${TEST_LOG} --test_all_versions # is parallel_tests 4 appropriate?
+planemo test_reports ${TEST_JSON} --test_output ${TEST_HTML}

--- a/jenkins/simple_install_test.sh
+++ b/jenkins/simple_install_test.sh
@@ -10,10 +10,14 @@ if [ ! $URL ] || [ ! $API_KEY ] || [ ! $LOG_DIR ]; then
     exit 1;
 fi
 
+LOG_DIR=${LOG_DIR}/build_${BUILD_NUMBER}
+mkdir -p $LOG_DIR
+
 INSTALL_LOG=${LOG_DIR}/${SECTION}_install_log.txt
 TEST_LOG=${LOG_DIR}/${SECTION}_test_log.txt
 TEST_JSON=${LOG_DIR}/${SECTION}_test.json
 TEST_HTML=${LOG_DIR}/${SECTION}_test.html
+cp $TOOL_FILE ${LOG_DIR}/$(basename $TOOL_FILE)
 
 shed-tools install -g ${URL} -a ${API_KEY} -t ${TOOL_FILE} -v --log_file ${INSTALL_LOG}
 shed-tools test -g ${URL} -a ${API_KEY} -t ${TOOL_FILE} --parallel_tests 4 --test_json ${TEST_JSON} -v --log_file ${TEST_LOG} --test_all_versions # is parallel_tests 4 appropriate?


### PR DESCRIPTION
Script to install and test from a single .yml file.

Usage:
```
export URL=https://staging.usegalaxy.org.au
export LOG_DIR=~/new_staging_tools
bash simple_install_test.sh usegalaxy.org.au/annotation.yml
```

The jenkins_bot api key for staging will be set from Jenkins.  This could be set to loop through all of the .yml files in usegalaxy.org.au or just install one at a time.  I'd like to try with just one to start with.  This can be marked as ready to merge when it has been tested on galaxy-cat.