### PR TITLE
Drop galaxy-util from jenkins requirements

### DIFF
--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -4,7 +4,6 @@ pytz
 -e git+https://github.com/cat-bro/ephemeris.git@master#egg=ephemeris
 bioblend==0.13.0
 planemo==0.70.0
-galaxy-util==20.5.0
 
 # requirements for galaxy virtualenv also required here for tests to run correctly
 pysam==0.15.2


### PR DESCRIPTION
This clashes with what ephemeris requires