### PR TITLE
GTN genome_annotation tools

### DIFF
--- a/requests/gtn_genome_annotation.yml
+++ b/requests/gtn_genome_annotation.yml
@@ -1,0 +1,21 @@
+tools:
+- name: maker
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: find_subsequences
+  owner: bgruening
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: gff_to_prot
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: bowtie_wrappers
+  owner: devteam
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: transit_gumbel
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
This includes devteam's `bowtie_wrappers` which is actually bowtie1

Also a new version of maker.  This one might run on slurm, the old one wouldn't.

jcvi_gff_stats is excluded from the list because has timed out with previous install attempts.