### PR TITLE
[FORCE] install translate bed skipping conda install

### DIFF
--- a/requests/translate_bed.yml
+++ b/requests/translate_bed.yml
@@ -1,0 +1,8 @@
+tools:
+- name: translate_bed
+  owner: galaxyp
+  revisions:
+  - 038ecf54cbec
+  tool_panel_section_label: Operate on Genomic Intervals
+  tool_shed_url: toolshed.g2.bx.psu.edu
+  install_resolver_dependencies: False


### PR DESCRIPTION
From the GTN smorgasboard list

The version of biopython that this requires (1.62) is not in conda and the environment will fail to install.  It passes its tests on staging with biopython 1.70 instead