### PR TITLE
[FORCE] seq_filter_by_id

### DIFF
--- a/requests/seq_filter_by_id.yml
+++ b/requests/seq_filter_by_id.yml
@@ -1,0 +1,7 @@
+tools:
+- name: seq_filter_by_id
+  owner: peterjc
+  revisions:
+  - 141612f8c3e3
+  tool_panel_section_label: Filter and Sort
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Needed for 'Understanding Barcodes' tutorial on Wednesday.

This works on dev but cannot be tested because the test data is missing from the repo.