### PR TITLE
msstats for new maxquant tutorial

### DIFF
--- a/requests/msstats.yml
+++ b/requests/msstats.yml
@@ -1,0 +1,5 @@
+tools:
+- name: msstats
+  owner: galaxyp
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Thursday's maxquant tutorial has just been merged into GTN.  GA has all of the tools except for this one.