### PR TITLE
leave git diff of changes out of jenkins log

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -162,10 +162,6 @@ install_tools() {
     COMMIT_FILES+=("$FILE")
   done
 
-  # log all git changes
-  git diff | cat;
-  git diff --staged | cat;
-
   echo -e "\nPushing Changes to github"
   COMMIT_MESSAGE="Jenkins $MODE build $BUILD_NUMBER."
   git commit "${COMMIT_FILES[@]}" -m "$COMMIT_MESSAGE"


### PR DESCRIPTION
the really long diff is annoying when reading the logs on jenkins and it doesn't seem that useful