### PR TITLE
install tool dependencies always with shed-tools install

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -213,7 +213,7 @@ install_tool() {
   galaxy-wait -g "https://${TOOL_SHED_URL}"
 
   # Ephemeris install script
-  command="shed-tools install -g $URL -a $API_KEY -t $TOOL_FILE -v --log_file $INSTALL_LOG"
+  command="shed-tools install -g $URL -a $API_KEY -t $TOOL_FILE -v --log_file $INSTALL_LOG --install_tool_dependencies"
   echo "${command/$API_KEY/<API_KEY>}"; # substitute API_KEY for printing
   {
     $command


### PR DESCRIPTION
This might be good to put this in ahead of GTN requests.  The current code puts the onus on the requester to have `install_tool_dependencies: true` in the yaml file but it's difficult to reinstall (because of repository dependencies that remain installed) if we find that we needed it.  It shouldn't have any effect on tools that do not have a legacy requirements.xml file.