### PR TITLE
Update organise_request_files and import fewer bioblend clients

### DIFF
--- a/scripts/is_tool_new.py
+++ b/scripts/is_tool_new.py
@@ -2,7 +2,6 @@ import sys
 import argparse
 
 from bioblend.galaxy import GalaxyInstance
-from bioblend.galaxy.toolshed import ToolShedClient
 
 
 def main():
@@ -18,10 +17,9 @@ def main():
     name = args.name
     owner = args.owner
 
-    gal = GalaxyInstance(galaxy_url, api_key)
-    cli = ToolShedClient(gal)
-    u_repos = cli.get_repositories()
-    tools_with_name_and_owner = [t for t in u_repos if t['name'] == name and t['owner'] == owner and t['status'] == 'Installed']
+    galaxy_instance = GalaxyInstance(galaxy_url, api_key)
+    repos = galaxy_instance.toolshed.get_repositories()
+    tools_with_name_and_owner = [t for t in repos if t['name'] == name and t['owner'] == owner and t['status'] == 'Installed']
     if not tools_with_name_and_owner:
         sys.stdout.write('True')  # we did not find the name/owner combination so we say that the tool is new
     else:

--- a/scripts/uninstall_tools.py
+++ b/scripts/uninstall_tools.py
@@ -1,7 +1,6 @@
 import argparse
 
 from bioblend.galaxy import GalaxyInstance
-from bioblend.galaxy.toolshed import ToolShedClient
 
 """
 Uninstall tools from a galaxy instance via the API using the bioblend package.
@@ -35,8 +34,7 @@ def main():
 def uninstall_tools(galaxy_server, api_key, names, force):
     tools_to_uninstall = []
     galaxy_instance = GalaxyInstance(url=galaxy_server, key=api_key)
-    toolshed_client = ToolShedClient(galaxy_instance)
-    installed_tools = [t for t in toolshed_client.get_repositories() if t['status'] != 'Uninstalled']
+    installed_tools = [t for t in galaxy_instance.toolshed.get_repositories() if t['status'] != 'Uninstalled']
 
     for name in names:
         revision = None
@@ -59,7 +57,7 @@ def uninstall_tools(galaxy_server, api_key, names, force):
     for tool in tools_to_uninstall:
         try:
             print('Uninstalling %s at revision %s' % (tool['name'], tool['changeset_revision']))
-            return_value = toolshed_client.uninstall_repository_revision(
+            return_value = galaxy_instance.toolshed.uninstall_repository_revision(
                 name=tool['name'],
                 owner=tool['owner'],
                 changeset_revision=tool['changeset_revision'],


### PR DESCRIPTION
Update organise_request_files check for version updates.  The old method was correct most of the time but would have been skipping tests more often than it needed to.  Make fewer calls to the 'get_repository_revision_install_info' endpoint.  Update some bioblend imports.