### PR TITLE
[FORCE] some tools from update 64

### DIFF
--- a/requests/dada2_assigntaxonomyaddspecies@63f86089423e.yml
+++ b/requests/dada2_assigntaxonomyaddspecies@63f86089423e.yml
@@ -1,0 +1,7 @@
+tools:
+- name: dada2_assigntaxonomyaddspecies
+  owner: iuc
+  revisions:
+  - 63f86089423e
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/genomescope@3169a38c2656.yml
+++ b/requests/genomescope@3169a38c2656.yml
@@ -1,0 +1,7 @@
+tools:
+- name: genomescope
+  owner: iuc
+  revisions:
+  - 3169a38c2656
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/humann_rename_table@71ea608ddfa3.yml
+++ b/requests/humann_rename_table@71ea608ddfa3.yml
@@ -1,0 +1,7 @@
+tools:
+- name: humann_rename_table
+  owner: iuc
+  revisions:
+  - 71ea608ddfa3
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/maxquant@e42225f8a659.yml
+++ b/requests/maxquant@e42225f8a659.yml
@@ -1,0 +1,7 @@
+tools:
+- name: maxquant
+  owner: galaxyp
+  revisions:
+  - e42225f8a659
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/metaphlan@a92a632c4d9b.yml
+++ b/requests/metaphlan@a92a632c4d9b.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metaphlan
+  owner: iuc
+  revisions:
+  - a92a632c4d9b
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/minimap2@09b53c1d4ab1.yml
+++ b/requests/minimap2@09b53c1d4ab1.yml
@@ -1,0 +1,7 @@
+tools:
+- name: minimap2
+  owner: iuc
+  revisions:
+  - 09b53c1d4ab1
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/query_tabular@623f3eb7aa48.yml
+++ b/requests/query_tabular@623f3eb7aa48.yml
@@ -1,0 +1,7 @@
+tools:
+- name: query_tabular
+  owner: iuc
+  revisions:
+  - 623f3eb7aa48
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/snippy@d220115f882b.yml
+++ b/requests/snippy@d220115f882b.yml
@@ -1,0 +1,7 @@
+tools:
+- name: snippy
+  owner: iuc
+  revisions:
+  - d220115f882b
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
maxquant has barely noticeable diffs in one of its output files for 1/8 tests, genomescope tests can't pass because they compare image files with exact diff, the rest have failed tests that use data tables.