### PR TITLE
[FORCE] rna_starsolo from update_64

### DIFF
--- a/requests/rna_starsolo@a6fba3d92531.yml
+++ b/requests/rna_starsolo@a6fba3d92531.yml
@@ -1,0 +1,7 @@
+tools:
+- name: rna_starsolo
+  owner: iuc
+  revisions:
+  - a6fba3d92531
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Tests are failing when the tests are run in parallel and passing when they are run one by one.  This is probably a bug in galaxy-tool-util because the test jobs are using the same input datasets even though the datasets are uploaded separately for each job.