### PR TITLE
Update jenkins requirements to add another ephemeris patch

### DIFF
--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -1,10 +1,9 @@
 arrow
 pyyaml
 pytz
--e git+https://github.com/cat-bro/ephemeris.git@release_0.10.7_plus_galaxywait_fix#egg=ephemeris
-bioblend>=0.13.0
 planemo==0.72.0
+-e git+https://github.com/cat-bro/ephemeris.git@release_0.10.7_cb_updates_20210727#egg=ephemeris
+galaxy-tool-util==21.1.2
 
 # requirements for galaxy virtualenv also required here for tests to run correctly
-pysam==0.16.0.1
 h5py==3.1.0


### PR DESCRIPTION
There's a change in 0.10.7 that strips the tool version from the tool id and it breaks testing for older tools, it means that it always downloads test-data files for the most recent version.

Also anchor galaxy-tool-util version and remove pysam and bioblend dependencies that are satisfied by installing ephemeris.