### PR TITLE
[FORCE] meryl, merqury from install_793

### DIFF
--- a/requests/merqury@9d79beb19ac3.yml
+++ b/requests/merqury@9d79beb19ac3.yml
@@ -1,0 +1,7 @@
+tools:
+- name: merqury
+  owner: iuc
+  revisions:
+  - 9d79beb19ac3
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/meryl@51c2360aa807.yml
+++ b/requests/meryl@51c2360aa807.yml
@@ -1,0 +1,7 @@
+tools:
+- name: meryl
+  owner: iuc
+  revisions:
+  - 51c2360aa807
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
meryl fails sim size tests

merqury tests cannot run because of mistakes in the test xml in the wrapper.  I'm working on corrections for this but it might take a while.  The tool can definitely run and produce output.