### PR TITLE
install humann

### DIFF
--- a/requests/humann.yml
+++ b/requests/humann.yml
@@ -1,0 +1,7 @@
+tools:
+- name: humann
+  owner: iuc
+  revisions:
+  - 6b7622dda516
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
For issue #562 and for GTN

The environment has been built in advance on staging and pawsey.  This will fail tests because of tests that use reference data but if it passes 1/6 on staging then it is working and can be force installed