### PR TITLE
[FORCE] canu, maxquant from update_79

### DIFF
--- a/requests/canu@86f150c8019d.yml
+++ b/requests/canu@86f150c8019d.yml
@@ -1,0 +1,7 @@
+tools:
+- name: canu
+  owner: bgruening
+  revisions:
+  - 86f150c8019d
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/maxquant@97a7f34fcb6a.yml
+++ b/requests/maxquant@97a7f34fcb6a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: maxquant
+  owner: galaxyp
+  revisions:
+  - 97a7f34fcb6a
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
canu fails tests on production with a message that there is not enough memory.  It passes the same tests on staging, probably because the slurm settings have not been updated there.

maxquant fails every week on staging with a test that passes on dev, no idea why... I think it's worth just installing this update.