### PR TITLE
set jenkins sleep before testing to 90 seconds

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -291,7 +291,7 @@ test_tool() {
   TEST_LOG="$TMP/test_log.txt"
   rm -f $TEST_LOG ||:;  # delete file if it exists
 
-  sleep 30s; # Allow time for handlers to catch up
+  sleep 90s; # Allow time for handlers to catch up
 
   # Wait for galaxy
   echo "Waiting for $URL";


### PR DESCRIPTION
Increase the waiting time before running tests to 90 seconds because last week some of the tool tests were not found.