### PR TITLE
install cuffdiff again

### DIFF
--- a/requests/cuffdiff.yml
+++ b/requests/cuffdiff.yml
@@ -1,0 +1,7 @@
+tools:
+- name: cuffdiff
+  owner: devteam
+  revisions:
+  - 43221aef70e2
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
GA used to have cuffdiff but lost it in the move to pawsey because the environment would not resolve.

For issue https://github.com/usegalaxy-au/usegalaxy-au-tools/issues/360