### PR TITLE
tool request: metaphlan2

### DIFF
--- a/requests/metaphlan2.yml
+++ b/requests/metaphlan2.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metaphlan2
+  owner: iuc
+  revisions:
+  - f60773e921fa
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
the environment for this is `mulled-v1-c5867e29ea0fba532ec8dc4a557d8798445dccb6ecf21f67e09143751a79b65d` and has been created on staging and production with `metaphlan2=2.6.0 bowtie2=2.3.0 python=2.7.15 tbb=2020.2`.  The tool wrapper asks for `metaphlan2=2.6.0 bowtie2=2.3.0 python=2.7.10`.  python 2.7.10 is no longer in conda, the earliest is 2.7.12.
