### PR TITLE
Add tools for Funannotate tutorial

### DIFF
--- a/requests/annotation.yml
+++ b/requests/annotation.yml
@@ -33,14 +33,12 @@ tools:
   owner: iuc
   revisions:
   - 0cadd0a04412
-  tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: data_manager_eggnog_mapper_abspath
   owner: galaxyp
   revisions:
   - fcb8bdd124f4
-  tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: eggnog_mapper
@@ -59,7 +57,6 @@ tools:
   owner: iuc
   revisions:
   - 7776cb18fdf8
-  tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: aegean_canongff3

--- a/requests/template/annotation.yml
+++ b/requests/template/annotation.yml
@@ -1,0 +1,88 @@
+tools:
+- name: funannotate_clean
+  owner: iuc
+  revisions:
+  - a230ea445788
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: funannotate_sort
+  owner: iuc
+  revisions:
+  - b3cf4684e9c7
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: funannotate_predict
+  owner: iuc
+  revisions:
+  - 2bba2ff070d9
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: funannotate_compare
+  owner: iuc
+  revisions:
+  - 563a19373357
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: funannotate_annotate
+  owner: iuc
+  revisions:
+  - 14f588312c56
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_funannotate
+  owner: iuc
+  revisions:
+  - 0cadd0a04412
+  tool_panel_section_id: None
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_eggnog_mapper_abspath
+  owner: galaxyp
+  revisions:
+  - fcb8bdd124f4
+  tool_panel_section_id: None
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: eggnog_mapper
+  owner: galaxyp
+  revisions:
+  - 63662ae295d6
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: interproscan
+  owner: bgruening
+  revisions:
+  - c55643c3d813
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: data_manager_interproscan
+  owner: iuc
+  revisions:
+  - 7776cb18fdf8
+  tool_panel_section_id: None
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: aegean_canongff3
+  owner: iuc
+  revisions:
+  - 3f438bf5475d
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: aegean_locuspocus
+  owner: iuc
+  revisions:
+  - c4ac24510b55
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: aegean_parseval
+  owner: iuc
+  revisions:
+  - 1b52f0c8ad7f
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: aegean_gaeval
+  owner: iuc
+  revisions:
+  - 1dd7adc21b6d
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Adding tools for the [Funannotate GTN tutorial](https://training.galaxyproject.org/training-material/topics/genome-annotation/tutorials/funannotate/tutorial.html)
There will be some data managers to run afterwards, and possibly [licensed components to install/configure for interproscan](https://github.com/galaxyproject/tools-iuc/blob/master/tools/interproscan/README.md#installing-licensed-components-manually) if you want to make them available (not mandatory)