### PR TITLE
[FORCE] ivar_trim, quast, breseq

### DIFF
--- a/requests/breseq@0d18a3ba2d1c.yml
+++ b/requests/breseq@0d18a3ba2d1c.yml
@@ -1,0 +1,7 @@
+tools:
+- name: breseq
+  owner: iuc
+  revisions:
+  - 0d18a3ba2d1c
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ivar_trim@9f978da6528a.yml
+++ b/requests/ivar_trim@9f978da6528a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ivar_trim
+  owner: iuc
+  revisions:
+  - 9f978da6528a
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/quast@675488238c96.yml
+++ b/requests/quast@675488238c96.yml
@@ -1,0 +1,7 @@
+tools:
+- name: quast
+  owner: iuc
+  revisions:
+  - 675488238c96
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
ivar_trim and breseq failed the tests that use data tables.  quast fails 2 tests (out of 7) with input staging problems - the last few revisions have had the same issue