### PR TITLE
Retry updating some tools

### DIFF
--- a/requests/antismash@bc88856eddab.yml
+++ b/requests/antismash@bc88856eddab.yml
@@ -1,0 +1,7 @@
+tools:
+- name: antismash
+  owner: bgruening
+  revisions:
+  - bc88856eddab
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bowtie2@f6877ad76b00.yml
+++ b/requests/bowtie2@f6877ad76b00.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bowtie2
+  owner: devteam
+  revisions:
+  - f6877ad76b00
+  tool_panel_section_label: Mapping
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/column_maker@6595517c2dd8.yml
+++ b/requests/column_maker@6595517c2dd8.yml
@@ -1,0 +1,7 @@
+tools:
+- name: column_maker
+  owner: devteam
+  revisions:
+  - 6595517c2dd8
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/lofreq_alnqual@791f73caa0c8.yml
+++ b/requests/lofreq_alnqual@791f73caa0c8.yml
@@ -1,0 +1,7 @@
+tools:
+- name: lofreq_alnqual
+  owner: iuc
+  revisions:
+  - 791f73caa0c8
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/metabat2@708abf08a626.yml
+++ b/requests/metabat2@708abf08a626.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metabat2
+  owner: iuc
+  revisions:
+  - 708abf08a626
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/pangolin@77402759b866.yml
+++ b/requests/pangolin@77402759b866.yml
@@ -2,6 +2,6 @@ tools:
 - name: pangolin
   owner: iuc
   revisions:
-  - 77402759b866
+  - 92dd6da871f4
   tool_panel_section_label: Phylogenetics
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/pangolin@77402759b866.yml
+++ b/requests/pangolin@77402759b866.yml
@@ -1,0 +1,7 @@
+tools:
+- name: pangolin
+  owner: iuc
+  revisions:
+  - 77402759b866
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/pangolin@77402759b866.yml
+++ b/requests/pangolin@77402759b866.yml
@@ -1,7 +1,0 @@
-tools:
-- name: pangolin
-  owner: iuc
-  revisions:
-  - 92dd6da871f4
-  tool_panel_section_label: Phylogenetics
-  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/rnaspades@378e55aeeb25.yml
+++ b/requests/rnaspades@378e55aeeb25.yml
@@ -1,0 +1,7 @@
+tools:
+- name: rnaspades
+  owner: iuc
+  revisions:
+  - 378e55aeeb25
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
retry antismash, bowtie2, metabat2, lofreq_alnqual, column_maker, rnaspades from update_110

All of these tools failed their tests on production because the tests were being set up before the handlers had updated.  The timeout between installing and updating has since been increased.