### PR TITLE
[FORCE] tools from update 110

### DIFF
--- a/requests/bcftools_mpileup@f506df85c652.yml
+++ b/requests/bcftools_mpileup@f506df85c652.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_mpileup
+  owner: iuc
+  revisions:
+  - f506df85c652
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ena_upload@d147d6455873.yml
+++ b/requests/ena_upload@d147d6455873.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ena_upload
+  owner: iuc
+  revisions:
+  - d147d6455873
+  tool_panel_section_label: Send Data
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ivar_trim@5671e1d3d5ee.yml
+++ b/requests/ivar_trim@5671e1d3d5ee.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ivar_trim
+  owner: iuc
+  revisions:
+  - 5671e1d3d5ee
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/meryl@29dabd8db6f2.yml
+++ b/requests/meryl@29dabd8db6f2.yml
@@ -1,0 +1,7 @@
+tools:
+- name: meryl
+  owner: iuc
+  revisions:
+  - 29dabd8db6f2
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/metaspades@606b09cc9860.yml
+++ b/requests/metaspades@606b09cc9860.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metaspades
+  owner: nml
+  revisions:
+  - 606b09cc9860
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/raxml@29ff6a849eac.yml
+++ b/requests/raxml@29ff6a849eac.yml
@@ -1,0 +1,7 @@
+tools:
+- name: raxml
+  owner: iuc
+  revisions:
+  - 29ff6a849eac
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/spades@78ced22d09a2.yml
+++ b/requests/spades@78ced22d09a2.yml
@@ -1,0 +1,7 @@
+tools:
+- name: spades
+  owner: nml
+  revisions:
+  - 78ced22d09a2
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/spades_plasmidspades@6aad515a5270.yml
+++ b/requests/spades_plasmidspades@6aad515a5270.yml
@@ -1,0 +1,7 @@
+tools:
+- name: spades_plasmidspades
+  owner: iuc
+  revisions:
+  - 6aad515a5270
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/spades_rnaviralspades@b3490b036c5a.yml
+++ b/requests/spades_rnaviralspades@b3490b036c5a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: spades_rnaviralspades
+  owner: iuc
+  revisions:
+  - b3490b036c5a
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Tools that fail ref data tests: bcftools_mpileup, ivar_trim
Tools that routinely fail a couple of tests with minor differences in output size: meryl, metaspades, raxml, spades, spades_plasmidspades, spades_rnaviralspades, ena_upload