### PR TITLE
Remove --parallel_tests from test command

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -291,14 +291,14 @@ test_tool() {
   TEST_LOG="$TMP/test_log.txt"
   rm -f $TEST_LOG ||:;  # delete file if it exists
 
-  sleep 180s; # Allow time for handlers to catch up
+  sleep 60s; # Allow time for handlers to catch up
 
   # Wait for galaxy
   echo "Waiting for $URL";
   galaxy-wait -g $URL
 
   TOOL_PARAMS="--name $TOOL_NAME --owner $OWNER --revisions $INSTALLED_REVISION --toolshed $TOOL_SHED_URL"
-  command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --parallel_tests 4 --test_json $TEST_JSON -v --log_file $TEST_LOG"
+  command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --test_json $TEST_JSON -v --log_file $TEST_LOG"
   echo "${command/$API_KEY/<API_KEY>}"
   {
     $command


### PR DESCRIPTION
With tools that run with singularity containers, the first job run will download from quay.io and build the sif file in /mnt/tools/cache/singularity.  If jobs are running in parallel, they are all trying to do this and it can result in the jobs failing and/or failing to build the sif file.

Also reduce the sleep from 180 to 60 seconds.