### PR TITLE
[FORCE] bcftools_mpileup from update_114

### DIFF
--- a/requests/bcftools_mpileup@31ea13dfe5e6.yml
+++ b/requests/bcftools_mpileup@31ea13dfe5e6.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_mpileup
+  owner: iuc
+  revisions:
+  - 31ea13dfe5e6
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
This failed last week because one of the tests uses test data tables.  I'm going to merge this straight away to check that Jenkins is working correctly after the update