### PR TITLE
[FORCE] tools from update 115

### DIFF
--- a/requests/eggnog_mapper@9d1fbff733cf.yml
+++ b/requests/eggnog_mapper@9d1fbff733cf.yml
@@ -1,0 +1,7 @@
+tools:
+- name: eggnog_mapper
+  owner: galaxyp
+  revisions:
+  - 9d1fbff733cf
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/genomescope@01210c4e9144.yml
+++ b/requests/genomescope@01210c4e9144.yml
@@ -1,0 +1,7 @@
+tools:
+- name: genomescope
+  owner: iuc
+  revisions:
+  - 01210c4e9144
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/hisat2@f4af63aaf57a.yml
+++ b/requests/hisat2@f4af63aaf57a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: hisat2
+  owner: iuc
+  revisions:
+  - f4af63aaf57a
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/interproscan@98cafcbd2578.yml
+++ b/requests/interproscan@98cafcbd2578.yml
@@ -1,0 +1,7 @@
+tools:
+- name: interproscan
+  owner: bgruening
+  revisions:
+  - 98cafcbd2578
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/keras_train_and_eval@e1317b5502fa.yml
+++ b/requests/keras_train_and_eval@e1317b5502fa.yml
@@ -1,0 +1,7 @@
+tools:
+- name: keras_train_and_eval
+  owner: bgruening
+  revisions:
+  - e1317b5502fa
+  tool_panel_section_label: Machine Learning
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/lofreq_call@4805fe3d8fda.yml
+++ b/requests/lofreq_call@4805fe3d8fda.yml
@@ -1,0 +1,7 @@
+tools:
+- name: lofreq_call
+  owner: iuc
+  revisions:
+  - 4805fe3d8fda
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/maxquant@1f39c833f65f.yml
+++ b/requests/maxquant@1f39c833f65f.yml
@@ -1,0 +1,7 @@
+tools:
+- name: maxquant
+  owner: galaxyp
+  revisions:
+  - 1f39c833f65f
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/metaspades@fd128c111ab0.yml
+++ b/requests/metaspades@fd128c111ab0.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metaspades
+  owner: nml
+  revisions:
+  - fd128c111ab0
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/quast@3061c8b029e5.yml
+++ b/requests/quast@3061c8b029e5.yml
@@ -1,0 +1,7 @@
+tools:
+- name: quast
+  owner: iuc
+  revisions:
+  - 3061c8b029e5
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/samtools_view@5826298f6a73.yml
+++ b/requests/samtools_view@5826298f6a73.yml
@@ -1,0 +1,7 @@
+tools:
+- name: samtools_view
+  owner: iuc
+  revisions:
+  - 5826298f6a73
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
eggnog_mapper, interproscan and keras_train_and_eval do not have tests that could possibly pass because all of the tests use data tables.

genomescope, hisat2, lofreq_call, maxquant, metaspades, quast, samtools_view have a minority of test failures for data table tests or minor diffs.