### PR TITLE
[FORCE] hifiadapterfilt update

### DIFF
--- a/requests/hifi.yml
+++ b/requests/hifi.yml
@@ -1,0 +1,7 @@
+tools:
+- name: hifiadapterfilt
+  owner: galaxy-australia
+  revisions:
+  - 03acc0e3772e
+  tool_panel_section_label: FASTA/FASTQ
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
This is an update with the same version as what is installed.  The update pipeline would recognise this and skip tests but the install pipeline does not, so [FORCE] is necessary