### PR TITLE
[FORCE] tool from update 132

### DIFF
--- a/requests/bcftools_consensus@147de996e34f.yml
+++ b/requests/bcftools_consensus@147de996e34f.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_consensus
+  owner: iuc
+  revisions:
+  - 147de996e34f
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_convert_to_vcf@4935320a59a8.yml
+++ b/requests/bcftools_convert_to_vcf@4935320a59a8.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_convert_to_vcf
+  owner: iuc
+  revisions:
+  - 4935320a59a8
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_csq@f01b2c9506b9.yml
+++ b/requests/bcftools_csq@f01b2c9506b9.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_csq
+  owner: iuc
+  revisions:
+  - f01b2c9506b9
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_mpileup@03191140c66a.yml
+++ b/requests/bcftools_mpileup@03191140c66a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_mpileup
+  owner: iuc
+  revisions:
+  - 03191140c66a
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_norm@ebb2e12a6de1.yml
+++ b/requests/bcftools_norm@ebb2e12a6de1.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_norm
+  owner: iuc
+  revisions:
+  - ebb2e12a6de1
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/bcftools_stats@a2f8dc22d7c0.yml
+++ b/requests/bcftools_stats@a2f8dc22d7c0.yml
@@ -1,0 +1,7 @@
+tools:
+- name: bcftools_stats
+  owner: iuc
+  revisions:
+  - a2f8dc22d7c0
+  tool_panel_section_label: VCF/BCF
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ena_upload@a62c4a11a67d.yml
+++ b/requests/ena_upload@a62c4a11a67d.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ena_upload
+  owner: iuc
+  revisions:
+  - a62c4a11a67d
+  tool_panel_section_label: Send Data
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/ivar_trim@e3bb03cf207a.yml
+++ b/requests/ivar_trim@e3bb03cf207a.yml
@@ -1,0 +1,7 @@
+tools:
+- name: ivar_trim
+  owner: iuc
+  revisions:
+  - e3bb03cf207a
+  tool_panel_section_label: iVar
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/maxquant@4d17fcdeb8ff.yml
+++ b/requests/maxquant@4d17fcdeb8ff.yml
@@ -1,0 +1,7 @@
+tools:
+- name: maxquant
+  owner: galaxyp
+  revisions:
+  - 4d17fcdeb8ff
+  tool_panel_section_label: Proteomics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/metaphlan@6dee4abadccb.yml
+++ b/requests/metaphlan@6dee4abadccb.yml
@@ -1,0 +1,7 @@
+tools:
+- name: metaphlan
+  owner: iuc
+  revisions:
+  - 6dee4abadccb
+  tool_panel_section_label: Metagenomic Analysis
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/raxml@ea30d3089354.yml
+++ b/requests/raxml@ea30d3089354.yml
@@ -1,0 +1,7 @@
+tools:
+- name: raxml
+  owner: iuc
+  revisions:
+  - ea30d3089354
+  tool_panel_section_label: Phylogenetics
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/salmon@ebab418107f5.yml
+++ b/requests/salmon@ebab418107f5.yml
@@ -1,0 +1,7 @@
+tools:
+- name: salmon
+  owner: bgruening
+  revisions:
+  - ebab418107f5
+  tool_panel_section_label: RNA-seq
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
bcftools_consensus, bcftools_convert_to_vcf, bcftools_csq, bcftools_mpileup, bcftools_norm, bcftools_stats, ena_upload, ivar_trim, maxquant, metaphlan, raxml, salmon

These mostly fail data table tests. Fine to update