### PR TITLE
[FORCE] install scanpy_run_umap

### DIFF
--- a/requests/scanpy_run_umap@0f98603d0116.yml
+++ b/requests/scanpy_run_umap@0f98603d0116.yml
@@ -1,0 +1,7 @@
+tools:
+- name: scanpy_run_umap
+  owner: ebi-gxa
+  revisions:
+  - 0f98603d0116
+  tool_panel_section_label: HCA Single-cell
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
There's no test data in the tool shed repo but there is in the git repo, this passes on dev when running galaxy-tool-test with the git repo data as test data path.