### PR TITLE
Remove owner from trusted list due to lack of test data

### DIFF
--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -44,7 +44,6 @@ trusted_owners:
 - owner: galaxy-australia
 - owner: rnateam
 - owner: bgruening
-- owner: ebi-gxa
 - owner: devteam
   skip_tools:
   - name: cuffdiff  # no longer supported


### PR DESCRIPTION
We can't automatically update tools from ebi-gxa because there are no test data files in the tool shed repositories, causing the tests to fail.

I'll add these tools to #864 