### PR TITLE
Update jenkins requirements and add an extra test to each installation

### DIFF
--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -291,7 +291,7 @@ test_tool() {
   TEST_LOG="$TMP/test_log.txt"
   rm -f $TEST_LOG ||:;  # delete file if it exists
 
-  sleep 60s; # Allow time for handlers to catch up
+  sleep 30s; # Allow time for handlers to catch up
 
   # Wait for galaxy
   echo "Waiting for $URL";
@@ -301,9 +301,16 @@ test_tool() {
   command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --test_json $TEST_JSON -v --log_file $TEST_LOG"
   echo "${command/$API_KEY/<API_KEY>}"
   {
+    # Run test command twice to account for the fact that the first test with a new container typically fails.
+    # This will not be necessary when containers are available from a nearby cvmfs stratum 1 server.
+    echo "Running dummy tests to allow for failure of first test in the event of a new singularity image"
+    $command
+    # Now the real thing
+    rm -f $TEST_JSON $TEST_LOG
+    echo "Running second set of tests (this one counts)"
     $command
   } || {
-    log_row "Shed-tools error";
+    log_row "Shed-tools test error";
     log_error $LOG_FILE
     exit_installation 1
     return 1

--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -2,8 +2,8 @@ arrow
 pyyaml
 pytz
 planemo==0.72.0
--e git+https://github.com/cat-bro/ephemeris.git@release_0.10.7_cb_updates_20210727#egg=ephemeris
-galaxy-tool-util==21.1.2
-
+ephemeris>=0.10.8
+galaxy-util==22.1.2
+galaxy-tool-util==22.1.2
 # requirements for galaxy virtualenv also required here for tests to run correctly
 h5py==3.1.0


### PR DESCRIPTION
Update requirements, since there is a new version of ephemeris and finally no need to use the fork. Pin galaxy-tool-util and galaxy-util to versions that are compatible with one another.

Get the installation script to run each set of tool tests twice. This is a brute force attempt to solve the problem caused by the first test failing when there is a new biocontainer. This won't be necessary once we can use containers from the aarnet cvmfs stratum 1, and seems OK as an interim solution.