### PR TITLE
Bump seq_filter_by_id

### DIFF
--- a/requests/seq_filter_by_id.yml
+++ b/requests/seq_filter_by_id.yml
@@ -1,0 +1,6 @@
+tools:
+  - name: seq_filter_by_id
+    owner: peterjc
+    tool_panel_section_label: Filter and sort
+    revisions:
+      - 85ef5f5a0562

--- a/requests/seq_filter_by_id.yml
+++ b/requests/seq_filter_by_id.yml
@@ -1,6 +1,6 @@
 tools:
   - name: seq_filter_by_id
     owner: peterjc
-    tool_panel_section_label: Filter and sort
+    tool_panel_section_label: Filter and Sort
     revisions:
       - 85ef5f5a0562


### PR DESCRIPTION
Bump version of seq_filter_by_id to get [this fix](https://github.com/peterjc/pico_galaxy/pull/41)
Resolves https://dhdnectar.freshdesk.com/a/tickets/190552 

Probably needs to be force installed like last time, but passes planemo test locally.
