### PR TITLE
Install PGAP

### DIFF
--- a/requests/pgap.yml
+++ b/requests/pgap.yml
@@ -1,0 +1,4 @@
+tools:
+  - name: pgap
+    owner: dereeper
+    tool_panel_section_label: Metagenomic Analysis


### PR DESCRIPTION
It's a pipeline - PGAP tool is included as folder instead of Conda package:
https://toolshed.g2.bx.psu.edu/repository?repository_id=b0fc108867dbc651&changeset_revision=e0c913351502

If it works, and we can't offer an alternative (NCBI-ready ouput), I don't see why we shouldn't provide the user with the functionality? PGAP is made by NCBI so it seems reasonable for us to have it on GA.

Ticket: https://support.ehelp.edu.au/a/tickets/107774

![image](https://github.com/usegalaxy-au/usegalaxy-au-tools/assets/42562517/7cfdd4e7-835a-4352-aa59-8d2a30102370)
