### PR TITLE
[FORCE] Bakta latest

### DIFF
--- a/requests/bakta_latest.yml
+++ b/requests/bakta_latest.yml
@@ -1,0 +1,6 @@
+tools:
+- name: bakta
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+

--- a/trusted_owners.yml
+++ b/trusted_owners.yml
@@ -31,7 +31,6 @@ trusted_owners:
   - name: gemini_annotate
   - name: gemini_query
   - name: gemini_comp_hets
-  - name: bakta  # Note: keep an eye on new revisions and ask BG
 - owner: simon-gladman
 - owner: nml
 - owner: peterjc


### PR DESCRIPTION
Install latest bakta. GA's version needs to be uninstalled and the data table entry removed because the loc file structure for bakta has changed and it will break galaxy if both exist.

Update: this is probably not the case and both versions can exist.