### PR TITLE
[FORCE] tools from install 1416

### DIFF
--- a/requests/kraken_taxonomy_report@latest.yml
+++ b/requests/kraken_taxonomy_report@latest.yml
@@ -1,0 +1,4 @@
+tools:
+- name: kraken_taxonomy_report
+  owner: iuc
+  tool_panel_section_label: Metagenomic Analysis

--- a/requests/medaka_variant_pipeline@latest.yml
+++ b/requests/medaka_variant_pipeline@latest.yml
@@ -1,0 +1,4 @@
+tools:
+- name: medaka_variant_pipeline
+  owner: iuc
+  tool_panel_section_label: Nanopore

--- a/requests/raceid_filtnormconf@latest.yml
+++ b/requests/raceid_filtnormconf@latest.yml
@@ -1,0 +1,4 @@
+tools:
+- name: raceid_filtnormconf
+  owner: iuc
+  tool_panel_section_label: Single-cell

--- a/requests/samtools_bam_to_cram@latest.yml
+++ b/requests/samtools_bam_to_cram@latest.yml
@@ -1,0 +1,4 @@
+tools:
+- name: samtools_bam_to_cram
+  owner: iuc
+  tool_panel_section_label: Convert Formats


### PR DESCRIPTION
kraken_taxonomy_report, medaka_variant_pipeline, raceid_filtnormconf, samtools_bam_to_cram

raceid_filtnormconf can't pass because of overly strict sim size comparison limits in tests, the rest use reference data in tests.
