### PR TITLE
MitoHiFi tool

### DIFF
--- a/requests/mitohifi.yml
+++ b/requests/mitohifi.yml
@@ -1,0 +1,7 @@
+tools:
+- name: mitohifi
+  owner: bgruening
+  revisions:
+  - 99ddbf037d98
+  tool_panel_section_label: Assembly
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
MitoHiFi is a python pipeline developed to finalize the assembly and annotation of mitogenomes.