### PR TITLE
Update jenkins requirements

### DIFF
--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -1,10 +1,9 @@
 arrow
 pyyaml
 pytz
-planemo==0.72.0
+planemo==0.75.21
 ephemeris>=0.10.8
-galaxy-util==22.1.2
-galaxy-tool-util==22.1.2
+galaxy-util==23.1.4
+galaxy-tool-util==23.1.4
 # requirements for galaxy virtualenv also required here for tests to run correctly
 h5py==3.1.0
-


### PR DESCRIPTION
Latest versions of galaxy-util and galaxy-tool-util are required to make use of new feature where test data can be downloaded. planemo also needs to be updated to work with these packages which is unfortunate because I liked the old-style test reports.