### PR TITLE
Adding: Clair3, Samtools_coverage, Bamtools split mapped, Split file on column and Updating Minimap2 

### DIFF
--- a/usegalaxy.org.au/mapping.yml
+++ b/usegalaxy.org.au/mapping.yml
@@ -57,18 +57,25 @@ tools:
 - name: minimap2
   owner: iuc
   revisions:
-  - be1d967337e4
-  - 6b1e195506a3
-  - f54f5baedfdd
-  - 53c0b7a1a0c3
   - 037c6e54df11
   - 09b53c1d4ab1
-  - c0c2d0941de8
-  - b3eab4b67562
+  - 11a0d50a54e6
+  - 1650a97189be
+  - 17e61517c166
+  - 1f06dccdc5d1
+  - 2445d53549ba
   - 3f4d6399997b
+  - 53c0b7a1a0c3
+  - 5cc34c3f440d
+  - 6b1e195506a3
+  - 6f50f36e4481
   - 77b2770508f6
   - 8c6cd2650d1f
-  - 11a0d50a54e6
+  - 92678fcb1a5f
+  - b3eab4b67562
+  - be1d967337e4
+  - c0c2d0941de8
+  - f54f5baedfdd
   tool_panel_section_label: Mapping
   tool_shed_url: toolshed.g2.bx.psu.edu
 - name: rna_starsolo

--- a/usegalaxy.org.au/sambam.yml
+++ b/usegalaxy.org.au/sambam.yml
@@ -1,4 +1,21 @@
 tools:
+- name: bamtools_split_mapped
+  owner: iuc
+  revisions:
+  - 2ed961caae0a
+  - 6dbef7ea2253
+  - fa7b5520ae53
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: samtools_coverage
+  owner: iuc
+  revisions:
+  - 8a477224dfee
+  - 90f2dd176d80
+  - ae36fab06bc2
+  - c4ff13d2aab3
+  tool_panel_section_label: SAM/BAM
+  tool_shed_url: toolshed.g2.bx.psu.edu
 - name: bam_to_sam
   owner: devteam
   revisions:

--- a/usegalaxy.org.au/text_manipulation.yml
+++ b/usegalaxy.org.au/text_manipulation.yml
@@ -1,4 +1,13 @@
 tools:
+- name: split_file_on_column
+  owner: bgruening
+  revisions:
+  - 37a53100b67e
+  - b60f2452580e
+  - d4b5b70e82cb
+  - ff2a81aa3f08
+  tool_panel_section_label: Text Manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu
 - name: add_line_to_file
   owner: bgruening
   revisions:

--- a/usegalaxy.org.au/variant_calling.yml
+++ b/usegalaxy.org.au/variant_calling.yml
@@ -1,4 +1,11 @@
 tools:
+- name: clair3
+  owner: iuc
+  revisions:
+  - 44f6ec903688
+  - 63e02ef6e153
+  tool_panel_section_label: Variant Calling
+  tool_shed_url: toolshed.g2.bx.psu.edu
 - name: breseq
   owner: iuc
   revisions:


### PR DESCRIPTION
Adding and updating tools, present in EU but not in org.au, these tools are needed for foodborne pathogen detection workflow PathoGFAIR to be publically available on org.au server

I also wanted to update [Build list](https://usegalaxy.org.au/root?tool_id=__BUILD_LIST__) tool from '1.1.0' to '1.2.0', but I couldn't find it in which yaml file.

Thanks,
Engy