### PR TITLE
stop production testing

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,8 @@ PRODUCTION_URL="https://usegalaxy.org.au"
 STAGING_TOOL_DIR="staging.gvl.org.au"
 PRODUCTION_TOOL_DIR="usegalaxy.org.au"
 
+SKIP_PRODUCTION_TESTS=1  # 1 means true in this universe
+
 BASE_LOG_DIR="/var/lib/jenkins/galaxy_tool_automation"
 VENV_PATH="/var/lib/jenkins/jobs_common"
 

--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -114,6 +114,11 @@ install_tools() {
     } && {
       echo -e "\nStep (3): Installing $TOOL_NAME on production server";
       install_tool "PRODUCTION"
+    } && {
+      if [ ! $SKIP_PRODUCTION_TESTS = 1 ]
+        echo -e "\nStep (4): Testing $TOOL_NAME on production server";
+        test_tool "PRODUCTION"
+      fi
     }
   done
 

--- a/jenkins/install_tools.sh
+++ b/jenkins/install_tools.sh
@@ -114,9 +114,6 @@ install_tools() {
     } && {
       echo -e "\nStep (3): Installing $TOOL_NAME on production server";
       install_tool "PRODUCTION"
-    } && {
-      echo -e "\nStep (4): Testing $TOOL_NAME on production server";
-      test_tool "PRODUCTION"
     }
   done
 
@@ -291,7 +288,7 @@ test_tool() {
   TEST_LOG="$TMP/test_log.txt"
   rm -f $TEST_LOG ||:;  # delete file if it exists
 
-  sleep 300s; # Allow time for handlers to catch up
+  sleep 60s; # Allow time for handlers to catch up
 
   # Wait for galaxy
   echo "Waiting for $URL";
@@ -301,14 +298,6 @@ test_tool() {
   command="shed-tools test -g $URL -a $API_KEY $TOOL_PARAMS --test_json $TEST_JSON -v --log_file $TEST_LOG"
   echo "${command/$API_KEY/<API_KEY>}"
   {
-    # Run test command twice to account for the fact that the first test with a new container typically fails.
-    # This will not be necessary when containers are available from a nearby cvmfs stratum 1 server.
-    echo "Running dummy tests to allow for failure of first test in the event of a new singularity image"
-    $command
-    sleep 60s;
-    # Now the real thing
-    rm -f $TEST_JSON $TEST_LOG
-    echo "Running second set of tests (this one counts)"
     $command
   } || {
     log_row "Shed-tools test error";

--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -1,9 +1,11 @@
 arrow
 pyyaml
 pytz
-planemo==0.75.21
+planemo==0.75.24
 ephemeris>=0.10.8
-galaxy-util==23.1.4
-galaxy-tool-util==23.1.4
+#galaxy-util==23.1.4
+galaxy-tool-util==24.1.1
 # requirements for galaxy virtualenv also required here for tests to run correctly
 h5py==3.1.0
+tifffile==2023.7.10
+pillow==10.3.0

--- a/jenkins/requirements.yml
+++ b/jenkins/requirements.yml
@@ -6,6 +6,6 @@ ephemeris>=0.10.8
 #galaxy-util==23.1.4
 galaxy-tool-util==24.1.1
 # requirements for galaxy virtualenv also required here for tests to run correctly
-h5py==3.1.0
+h5py==3.11.0
 tifffile==2023.7.10
 pillow==10.3.0


### PR DESCRIPTION
Remove second set of tests from staging server and remove testing from production altogether.

For some time, the tool tests on production immediately after installation have been chaotic. Tools are prone to fail tests because the API calls to get the test data or test files fail, and then the whole installation is rolled back. This could be due to multiple gunicorn processes or the migrations of galaxy's API to fastapi or something else. We can rely on the staging tests.

