### PR TITLE
update dorado wrapper

### DIFF
--- a/requests/dorado_update.yaml
+++ b/requests/dorado_update.yaml
@@ -1,0 +1,11 @@
+tools:
+  - name: dorado
+    owner: galaxy-australia
+    tool_panel_section_label: Nanopore
+    revisions:
+    - fc5b6491cf78
+  - name: dorado_pod5_convert
+    owner: galaxy-australia
+    tool_panel_section_label: Nanopore
+    revisions:
+    - 28928576e1ea


### PR DESCRIPTION
These versions target 24.1 and use the `pod5` datatype. dorado will fail tests but I've tested it on dev. dorado_pod5_convert should pass tests.