### PR TITLE
Add two more GTN tools

### DIFF
--- a/requests/gtn_20241004.yml
+++ b/requests/gtn_20241004.yml
@@ -1,0 +1,9 @@
+tools:
+- name: gprofiler_gost
+  owner: iuc
+  tool_panel_section_label: Annotation
+  tool_shed_url: toolshed.g2.bx.psu.edu
+- name: ctb_im_conformers
+  owner: bgruening
+  tool_panel_section_label: ChemicalToolBox
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
These two tools will enable 'qcxms-predictions' and 'GO-enrichment' tutorials.

GTN content is not completely covered on GA - there is some missingness in the Ecology section and miscellaneous tutorial tools that don't seem to be installed on other Galaxy servers and have unknown owners.