### PR TITLE
[FORCE] Bump AlphaFold to version 2.3.2_2

### DIFF
--- a/requests/alphafold-bump.yml
+++ b/requests/alphafold-bump.yml
@@ -1,0 +1,4 @@
+tools:
+  - name: alphafold2
+    owner: galaxy-australia
+    tool_panel_section_label: Proteomic AI


### PR DESCRIPTION
Just patched a bug running multimer with `disable_amber_relax`. Is it possible to run this before next wednesday? Or could I just manually update in the web admin?