### PR TITLE
install data manager for spaln

### DIFF
--- a/requests/data_manager_ncbi_taxonomy_sqlite.yml
+++ b/requests/data_manager_ncbi_taxonomy_sqlite.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_ncbi_taxonomy_sqlite
+  owner: iuc
+  revisions:
+  - f9650b178bfd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
the tool list_spaln_tables uses data table data (this data is also missing on Galaxy Europe)